### PR TITLE
fixed import generation for js tests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 9.5.1
+
+* Fixed broken import generation for js tests.
+
 Version 9.5.0
 
 * Added support for polyfilling `Symbol` if required.

--- a/modules/sample/package.json
+++ b/modules/sample/package.json
@@ -5,9 +5,11 @@
   "license": "Apache-2.0",
   "scripts": {
     "test-samples-pass": "../server/bin/bedrock-auto.js -b phantomjs --config tsconfig.json --files src/test/ts/**/*PassTest.ts src/test/ts/**/*PassTest.tsx",
+    "test-samples-pass-js": "../server/bin/bedrock-auto.js -b phantomjs --files src/test/js/**/*PassTest.js",
     "test-samples-pass-manual": "../server/bin/bedrock.js --config tsconfig.json --files src/test/ts/**/*PassTest.ts src/test/ts/**/*PassTest.tsx",
+    "test-samples-pass-manual-js": "../server/bin/bedrock.js --files src/test/js/**/*PassTest.js",
     "test-samples-fail": "../server/bin/bedrock-auto.js -b phantomjs --config tsconfig.json --files src/test/ts/**/*FailTest.ts",
-    "test": "yarn test-samples-pass"
+    "test": "yarn test-samples-pass && yarn test-samples-pass-js"
   },
   "dependencies": {
     "@ephox/bedrock-client": "^9.3.2"

--- a/modules/sample/src/test/js/client/SyncPassTest.js
+++ b/modules/sample/src/test/js/client/SyncPassTest.js
@@ -1,0 +1,5 @@
+import { UnitTest, assert } from '@ephox/bedrock-client'
+
+UnitTest.test('SyncPass Test', function () {
+  assert.eq(1, 1);
+});

--- a/modules/server/src/main/ts/bedrock/compiler/Imports.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Imports.ts
@@ -102,7 +102,7 @@ var addTest = function (testFilePath) {
 };
 var handleParseError = function (testFilePath, error) {
   ${useRequire ? 'var UnitTest = require(\'@ephox/bedrock-client\').UnitTest;' : 'import { UnitTest } from \'@ephox/bedrock-client\';'}
-  UnitTest.test(testFilePath', function () { throw error; });
+  UnitTest.test(testFilePath, function () { throw error; });
 };
 `,
     imports,


### PR DESCRIPTION
I noticed that the import file was corrupt when updating bedrock to the latest version.