### PR TITLE
TINY-4713: Fixed bedrock ending up in an infinite compilation loop

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Version 9.5.1
 
 * Fixed broken import generation for js tests.
+* Fixed webpack getting stuck in an infinite compilation loop when compiling many tests.
 
 Version 9.5.0
 

--- a/modules/server/src/main/ts/bedrock/compiler/Imports.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Imports.ts
@@ -62,7 +62,8 @@ const addTest = (testFilePath: string) => {
 };
 const handleImportError = (testFilePath: string, error: any) => {
   ${useRequire ? 'const UnitTest = require(\'@ephox/bedrock-client\').UnitTest;' : 'import { UnitTest } from \'@ephox/bedrock-client\';'}
-  UnitTest.test('Import Error - ' + testFilePath, () => { throw error; });
+  UnitTest.test('Import Error', () => { throw error; });
+  addTest(testFilePath);
 };
 
 let __currentTestFile;
@@ -104,7 +105,8 @@ var addTest = function (testFilePath) {
 };
 var handleImportError = function (testFilePath, error) {
   ${useRequire ? 'var UnitTest = require(\'@ephox/bedrock-client\').UnitTest;' : 'import { UnitTest } from \'@ephox/bedrock-client\';'}
-  UnitTest.test('Import Error - ' + testFilePath, function () { throw error; });
+  UnitTest.test('Import Error', function () { throw error; });
+  addTest(testFilePath);
 };
 
 var __currentTestFile;

--- a/modules/server/src/main/ts/bedrock/compiler/Imports.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Imports.ts
@@ -16,9 +16,9 @@ const filePathToImport = (useRequire: boolean, scratchFile: string) => {
 
     const importString = useRequire ? `require("${relativePath}");` : `import "${relativePath}";`;
     return `
-  __currentTestFile = "${filePath}";
-  ${importString}
-  addTest("${filePath}");`;
+__currentTestFile = "${filePath}";
+${importString}
+addTest("${filePath}");`;
   };
 };
 
@@ -39,6 +39,7 @@ declare let require: any;
 declare let __tests: any;
 declare let console: any;
 let __lastTestIndex: number = -1;
+let __currentTestFile;
 const addTest = (testFilePath: string) => {
   if (__tests && __tests[__tests.length - 1]) {
     const lastTest = __tests[__tests.length - 1];
@@ -60,18 +61,20 @@ const addTest = (testFilePath: string) => {
     console.error('no test list to add tests to');
   }
 };
-const handleImportError = (testFilePath: string, error: any) => {
-  ${useRequire ? 'const UnitTest = require(\'@ephox/bedrock-client\').UnitTest;' : 'import { UnitTest } from \'@ephox/bedrock-client\';'}
-  UnitTest.test('Import Error', () => { throw error; });
-  addTest(testFilePath);
-};
 
-let __currentTestFile;
-try {
+window.addEventListener('error', (event: any) => { 
+  ${useRequire ? 'const UnitTest = require(\'@ephox/bedrock-client\').UnitTest;' : 'import { UnitTest } from \'@ephox/bedrock-client\';'}
+  UnitTest.test('Error', () => {
+    if (event.error) {
+      throw event.error;
+    } else {
+      throw new Error(event.message);
+    }
+  });
+  addTest(__currentTestFile);
+});
+
 ${imports}
-} catch (e) {
-  handleImportError(__currentTestFile, e);
-}
 
 export {};`;
 };
@@ -82,6 +85,7 @@ const generateImportsJs = (useRequire: boolean, scratchFile: string, srcFiles: s
   return `${generatePolyfills(useRequire)}
 
 var __lastTestIndex = -1;
+var __currentTestFile;
 var addTest = function (testFilePath) {
   if (__tests && __tests[__tests.length - 1]) {
     var lastTest = __tests[__tests.length - 1];
@@ -103,18 +107,20 @@ var addTest = function (testFilePath) {
     console.error('no test list to add tests to');
   }
 };
-var handleImportError = function (testFilePath, error) {
-  ${useRequire ? 'var UnitTest = require(\'@ephox/bedrock-client\').UnitTest;' : 'import { UnitTest } from \'@ephox/bedrock-client\';'}
-  UnitTest.test('Import Error', function () { throw error; });
-  addTest(testFilePath);
-};
 
-var __currentTestFile;
-try {
+window.addEventListener('error', function (event) {
+  ${useRequire ? 'var UnitTest = require(\'@ephox/bedrock-client\').UnitTest;' : 'import { UnitTest } from \'@ephox/bedrock-client\';'}
+  UnitTest.test('Error', function () {
+    if (event.error) {
+      throw event.error;
+    } else {
+      throw new Error(event.message);
+    }
+  });
+  addTest(__currentTestFile);
+});
+
 ${imports}
-} catch (e) {
-  handleImportError(__currentTestFile, e);
-}
 
 export {};`;
 };


### PR DESCRIPTION
I'm not entirely sure why, but it seems as though webpack or one of the loaders we're using ends up in an infinite compilation loop when there's too many try/catch statements.

Previously we had a try/catch statement for each test, however to prevent the infinite loop I've changed this back to just one global catch all. This does mean other tests can't run if one has an import error, but at least with this change we'll still know that tests failed to run.

Here's an example of what the failure looks like:
```
-------------------------------------------------------------------------------
Test failed: Import Error - src/test/ts/client/SyncPassTest.ts (undefined)
TypeError: undefined is not a function (evaluating 'window.blah()')

Logs:


-------------------------------------------------------------------------------
Some tests failed. See {scratch/TEST-bedrock-run.xml} for details.
```