### PR TITLE
Restored JS source maps

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @spocke @jhaines @metricjs @lnewson @ltrouton @tinydylan

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 9.5.2
+
+* Fixed JS sourcemaps not working in bedrock manual mode.
+
 Version 9.5.1
 
 * Fixed broken import generation for js tests.
@@ -31,7 +35,7 @@ Version 9.3.0
 
 Version 9.2.1
 
-* Fixed sourcemaps not working in bedrock manual mode.
+* Fixed TS sourcemaps not working in bedrock manual mode.
 
 Version 9.2.0
 

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -236,10 +236,10 @@ const getTsCompileInfo = (tsConfigFile: string, scratchDir: string, basedir: str
   });
 };
 
-const getJsCompileInfo = (scratchDir: string, basedir: string, coverage: string[]): Promise<CompileInfo> => {
+const getJsCompileInfo = (scratchDir: string, basedir: string, manualMode: boolean, coverage: string[]): Promise<CompileInfo> => {
   const scratchFile = path.join(scratchDir, 'compiled/tests-imports.js');
   const dest = path.join(scratchDir, 'compiled/tests.js');
-  const config = getWebPackConfigJs(scratchFile, dest, coverage, false, basedir);
+  const config = getWebPackConfigJs(scratchFile, dest, coverage, manualMode, basedir);
 
   return Promise.resolve({ scratchFile, dest, config });
 };
@@ -248,7 +248,7 @@ const getCompileInfo = (tsConfigFile: string, scratchDir: string, basedir: strin
   if (hasTs(srcFiles)) {
     return getTsCompileInfo(tsConfigFile, scratchDir, basedir, manualMode, coverage);
   } else {
-    return getJsCompileInfo(scratchDir, basedir, coverage);
+    return getJsCompileInfo(scratchDir, basedir, manualMode, coverage);
   }
 };
 


### PR DESCRIPTION
Follow up to TINY-4269, which only fixed TypeScript source maps (and the "unused param" was later removed)