### PR TITLE
TINY-6204: Fixed tests getting stuck when reaching the maximum retry count

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 9.6.2
+
+* Fixed tests getting stuck when reaching the maximum retry count.
+
 Version 9.6.1
 
 * Fixed incorrectly reported test times.

--- a/modules/runner/src/main/ts/core/Utils.ts
+++ b/modules/runner/src/main/ts/core/Utils.ts
@@ -1,7 +1,7 @@
 export const noop = (): void => {};
 
 export const makeQueryParams = (session: string, offset: number, failed: number, retry: number): string => {
-  if (offset > 0) {
+  if (offset > 0 || retry > 0) {
     const rt = (retry > 0 ? '&retry=' + retry : '');
     return '?session=' + session + '&offset=' + offset + '&failed=' + failed + rt;
   } else {

--- a/modules/runner/src/main/ts/ui/Actions.ts
+++ b/modules/runner/src/main/ts/ui/Actions.ts
@@ -21,7 +21,7 @@ export const Actions = (session: string): Actions => {
 
   return {
     restartTests: () => reloadPage(0, 0),
-    retryTest: reloadPage,
+    retryTest: (offset, failed, retry) => reloadPage(offset, failed - 1, retry),
     skipTest: (offset, failed) => reloadPage(offset + 1, failed),
     reloadPage,
     updateHistory

--- a/modules/runner/src/test/ts/core/UtilsTest.ts
+++ b/modules/runner/src/test/ts/core/UtilsTest.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'mocha';
 import * as Utils from '../../../main/ts/core/Utils';
 
 describe('Utils.makeQueryParams', () => {
-  it('should be empty if offset is 0', () => {
+  it('should be empty if offset and retry is 0', () => {
     const str = Utils.makeQueryParams('1', 0, 1, 0);
     assert.equal(str, '');
   });
@@ -12,6 +12,12 @@ describe('Utils.makeQueryParams', () => {
   it('should always include a session, offset and failed params if offset > 0', () => {
     fc.assert(fc.property(fc.hexaString(), fc.integer(1, 1000), fc.nat(), (session, offset, failed) => {
       assert.equal(Utils.makeQueryParams(session, offset, failed, 0), '?session=' + session + '&offset=' + offset + '&failed=' + failed);
+    }))
+  });
+
+  it('should always include a session, offset and failed params if retries > 0', () => {
+    fc.assert(fc.property(fc.hexaString(), fc.integer(1, 1000), fc.nat(), (session, retries, failed) => {
+      assert.equal(Utils.makeQueryParams(session, 0, failed, retries), '?session=' + session + '&offset=' + 0 + '&failed=' + failed + '&retry=' + retries);
     }))
   });
 


### PR DESCRIPTION
This was caused by the `loadNextTest` not actually increasing the offset, so it never actually automatically moved to the next test. I also found out the failed count wasn't being updated when retrying either and the retry functionality didn't work if the very first test failed (both were older issues).