### PR TITLE
TINY-6218: Use glob to improve test directory scanning on windows

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 9.6.3
+
+* Changed the `--testdir` and `--testdirs` command line parameters to expand glob patterns
+
 Version 9.6.2
 
 * Fixed tests getting stuck when reaching the maximum retry count.

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -28,6 +28,7 @@
     "finalhandler": "^1.1.2",
     "fork-ts-checker-webpack-plugin": "~1.0.4",
     "fresh": "^0.5.2",
+    "glob": "^7.1.6",
     "grunt": "^1.0.4",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jquery": "^3.4.1",

--- a/modules/server/src/test/ts/ValidationTest.ts
+++ b/modules/server/src/test/ts/ValidationTest.ts
@@ -37,7 +37,7 @@ describe('Validation', () => {
   checkErrors(
     'Testing a directory -> files where the directory does not exist',
     [
-      '[test/resources.not.existing] is not a directory'
+      '[test/resources.not.existing] does not match any directories'
     ],
     [
       {name: 'testdir', validate: Extraction.files(['Test.js']), description: 'blah'}
@@ -75,6 +75,23 @@ describe('Validation', () => {
     ],
     {
       testdir: 'src/test/resources'
+    }
+  );
+
+  checkResult(
+    'Testing a directory -> glob search for directories',
+    {
+      other: [
+        'src/test/resources/html/screen.html',
+        'src/test/resources/test.file1',
+        'src/test/resources/tsconfig.sample.json'
+      ]
+    },
+    [
+      {name: 'testdir', validate: Extraction.files(['']), output: 'other', description: 'blah'}
+    ],
+    {
+      testdir: 'src/*/resources'
     }
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5113,11 +5113,6 @@ is-plain-object@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-4.1.1.tgz#1a14d6452cbd50790edc7fdaa0aed5a40a35ebb5"
   integrity sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==
 
-is-promise@^2.1.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
-  integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
-
 is-reference@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.1.4.tgz#3f95849886ddb70256a3e6d062b1a68c13c51427"


### PR DESCRIPTION
As a side effect of this, `--testdir` can now use globs to search multiple directories (on windows, *nix will still fail because the shell expands it). This happened because difference between `--testdir` and `--testdirs` is only in the command line parsing, they have identical implementations. I figured this was ok.