### PR TITLE
Fixed IE 11 not shutting down with newer IEDriverServer versions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 9.7.1
+
+* Fixed IE 11 not shutting down with newer IEDriverServer versions.
+
 Version 9.7.0
 
 * Added support for the new Chromium based Microsoft Edge Browser.


### PR DESCRIPTION
When using the latest version of 3.x for IEDriverServer, the `deleteSession()` call is being ignored when called too quickly, so we just need to introduce a small delay.

Have tested this branch using the driver from https://github.com/SeleniumHQ/selenium/tree/trunk/cpp/prebuilt/Win32/Release (3.105.1.1)