### PR TITLE
Fixed linter issues and ensured linting is run when running tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,23 +1,26 @@
 module.exports = {
-  extends: "eslint:recommended",
+  parser:  '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends:  [
+    'plugin:@typescript-eslint/recommended'
+  ],
   parserOptions: {
-    ecmaVersion: 11,
-    sourceType: "module",
-    ecmaFeatures: {
-      impliedStrict: true
-    }
+    sourceType: 'module'
   },
   rules: {
-    "curly": ["error", "multi-line"],
-    "object-curly-spacing": "off",
-    "array-bracket-spacing": "off",
-    "space-before-function-paren": "off",
-    "no-trailing-spaces": "off",
-    "indent": ["error", 2],
-    "max-len": "off",
-    "no-prototype-builtins": "off"
+    'curly': ['error', 'multi-line'],
+    'object-curly-spacing': 'off',
+    'array-bracket-spacing': 'off',
+    'space-before-function-paren': 'off',
+    'no-trailing-spaces': 'off',
+    'indent': ['error', 2],
+    'max-len': 'off',
+    'no-prototype-builtins': 'off',
+    'object-shorthand': 'error',
+    'quotes': [ 'error', 'single', { 'allowTemplateLiterals': true } ],
+    'semi': 'error'
   },
-  "env": {
-    "node": true
+  env: {
+    node: true
   }
 };

--- a/modules/client/.eslintrc.js
+++ b/modules/client/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports =  {
   root: true,
   parser:  '@typescript-eslint/parser',
-  plugins: ["@typescript-eslint"],
+  plugins: ['@typescript-eslint'],
   extends:  [
     'plugin:@typescript-eslint/recommended',
   ],
@@ -9,11 +9,16 @@ module.exports =  {
     sourceType:  'module',
   },
   rules:  {
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-use-before-define": "off"
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': [ 'error', { 'allowArgumentsExplicitlyTypedAsAny': true }],
+
+    'object-shorthand': 'error',
+    'quotes': [ 'error', 'single', { 'allowTemplateLiterals': true } ],
+    'semi': 'error'
   },
-  "env": {
-    "browser": true,
+  env: {
+    browser: true,
   }
 };

--- a/modules/client/src/main/ts/api/LegacyAssert.ts
+++ b/modules/client/src/main/ts/api/LegacyAssert.ts
@@ -1,14 +1,14 @@
 import * as Compare from '../core/Compare';
 import { TestLabel } from './TestLabel';
 
-const eq = function (expected: any, actual: any, message?: TestLabel) {
+const eq = function (expected: any, actual: any, message?: TestLabel): void {
   const result = Compare.compare(expected, actual);
   if (!result.eq) {
     throw new Error(TestLabel.asStringOr(message, result.why));
   }
 };
 
-const throws = function (f: () => void, expected?: string, message?: TestLabel) {
+const throws = function (f: () => void, expected?: string, message?: TestLabel): void {
   const token = {};
 
   try {
@@ -25,7 +25,7 @@ const throws = function (f: () => void, expected?: string, message?: TestLabel) 
   }
 };
 
-const throwsError = function (f: () => void, expected?: string, message?: TestLabel) {
+const throwsError = function (f: () => void, expected?: string, message?: TestLabel): void {
   const token = {};
 
   try {
@@ -42,7 +42,7 @@ const throwsError = function (f: () => void, expected?: string, message?: TestLa
   }
 };
 
-const succeeds = function (f: () => void, message?: TestLabel) {
+const succeeds = function (f: () => void, message?: TestLabel): void {
   try {
     f();
   } catch (e) {
@@ -50,7 +50,7 @@ const succeeds = function (f: () => void, message?: TestLabel) {
   }
 };
 
-const fail = function (message?: TestLabel) {
+const fail = function (message?: TestLabel): void {
   throw new Error(TestLabel.asStringOr(message, () => 'Test failed'));
 };
 

--- a/modules/client/src/main/ts/api/NewAssert.ts
+++ b/modules/client/src/main/ts/api/NewAssert.ts
@@ -2,7 +2,7 @@ import { Testable, Pprint } from '@ephox/dispute';
 import { TestLabel } from './TestLabel';
 import { TestError } from '@ephox/bedrock-common';
 
-const eq = function <T> (message: TestLabel, expected: T, actual: T, tt: Testable.Testable<T> = Testable.tAny) {
+const eq = function <T> (message: TestLabel, expected: T, actual: T, tt: Testable.Testable<T> = Testable.tAny): void {
   const result = tt.eq(expected, actual);
   if (!result) {
     const sMessage = TestLabel.asString(message);
@@ -12,7 +12,7 @@ const eq = function <T> (message: TestLabel, expected: T, actual: T, tt: Testabl
   }
 };
 
-const throws = function (message: TestLabel, f: () => void, expected?: string) {
+const throws = function (message: TestLabel, f: () => void, expected?: string): void {
   const token = {};
 
   try {
@@ -29,7 +29,7 @@ const throws = function (message: TestLabel, f: () => void, expected?: string) {
   }
 };
 
-const throwsError = function (message: TestLabel, f: () => void, expected?: string) {
+const throwsError = function (message: TestLabel, f: () => void, expected?: string): void {
   const token = {};
 
   try {
@@ -46,7 +46,7 @@ const throwsError = function (message: TestLabel, f: () => void, expected?: stri
   }
 };
 
-const succeeds = function (message: TestLabel, f: () => void) {
+const succeeds = function (message: TestLabel, f: () => void): void {
   try {
     f();
   } catch (e) {
@@ -54,7 +54,7 @@ const succeeds = function (message: TestLabel, f: () => void) {
   }
 };
 
-const fail = function (message: TestLabel) {
+const fail = function (message: TestLabel): void {
   throw new Error('Test failed\n' + TestLabel.asString(message));
 };
 

--- a/modules/client/src/main/ts/api/UnitTest.ts
+++ b/modules/client/src/main/ts/api/UnitTest.ts
@@ -1,5 +1,5 @@
-import { TestLabel } from "./TestLabel";
-import { TestLogEntry, TestLogs } from "./TestLogs";
+import { TestLabel } from './TestLabel';
+import { TestLogEntry, TestLogs } from './TestLogs';
 import { TestError, LoggedError } from '@ephox/bedrock-common';
 
 type TestError = TestError.TestError;
@@ -24,7 +24,7 @@ const register = (name: string, test: (success: () => void, failure: (e: LoggedE
     Global.__tests = [];
   }
 
-  Global.__tests.push({name: name, test: test});
+  Global.__tests.push({name, test});
 };
 
 const cleanStack = (error: Error, linesToRemove = 1) => {
@@ -78,7 +78,7 @@ const processLog = (logs: TestLogs): string[] => {
           ).concat(traceLines);
         }
       })();
-      everything = everything.concat(output)
+      everything = everything.concat(output);
     }
     return everything;
   };
@@ -92,11 +92,11 @@ const prepFailure = (err: TestThrowable, logs: TestLogs = TestLogs.emptyLogs()):
   return {
     error: normalizedErr,
     logs: failureMessage,
-  }
+  };
 };
 
 /** An asynchronous test with callbacks. */
-export const asyncTest = (name: string, test: (success: SuccessCallback, failure: FailureCallback) => void) => {
+export const asyncTest = (name: string, test: (success: SuccessCallback, failure: FailureCallback) => void): void => {
   register(name, function (success: () => void, failure: (e: LoggedError) => void) {
     try {
       test(success, function (err: TestThrowable, logs: TestLogs = TestLogs.emptyLogs()) {
@@ -114,7 +114,7 @@ export const asyncTest = (name: string, test: (success: SuccessCallback, failure
 export const asynctest = asyncTest;
 
 /** A synchronous test that fails if an exception is thrown */
-export const test = (name: string, test: () => void) => {
+export const test = (name: string, test: () => void): void => {
   register(name, function (success: () => void, failure: (e: LoggedError) => void) {
     try {
       test();
@@ -127,7 +127,7 @@ export const test = (name: string, test: () => void) => {
 };
 
 /** Tests an async function (function that returns a Promise). */
-export const promiseTest = (name: string, test: () => Promise<void>) =>
+export const promiseTest = (name: string, test: () => Promise<void>): void =>
   asyncTest(name, (success, failure) => {
     test().then(success).catch(failure);
   });

--- a/modules/client/src/main/ts/core/Compare.ts
+++ b/modules/client/src/main/ts/core/Compare.ts
@@ -6,7 +6,7 @@ const Arr = {
 };
 
 const Obj = {
-  keys: (obj: object): string[] =>
+  keys: (obj: Record<string, unknown>): string[] =>
     Object.keys(obj)
 };
 
@@ -16,10 +16,10 @@ export interface Comparison {
 }
 
 const pass = (): Comparison =>
-  ({eq: true, why: () => ''});
+  ({ eq: true, why: () => '' });
 
 const fail = (why: () => string): Comparison =>
-  ({eq: false, why: why});
+  ({ eq: false, why });
 
 const failCompare = (x: any, y: any, prefix?: string): Comparison => {
   return fail(() => (prefix || 'Values were different') + ': [' + String(x) + '] vs [' + String(y) + ']');
@@ -48,7 +48,7 @@ const sortArray = (x: any[]): any[] => {
   return y;
 };
 
-const sortedKeys = (o: object) =>
+const sortedKeys = (o: Record<string, unknown>) =>
   sortArray(Obj.keys(o));
 
 const compareObjects = (x: any, y: any) => {

--- a/modules/client/src/main/ts/core/Type.ts
+++ b/modules/client/src/main/ts/core/Type.ts
@@ -1,4 +1,4 @@
-export const typeOf = function (x: any) {
+export const typeOf = function (x: any): string {
   if (x === null) {
     return 'null';
   }

--- a/modules/client/src/test/ts/NewAssertTest.ts
+++ b/modules/client/src/test/ts/NewAssertTest.ts
@@ -1,37 +1,36 @@
+import { TestError } from '@ephox/bedrock-common';
+import { Testable } from '@ephox/dispute';
+import * as chai from 'chai';
+import * as fc from 'fast-check';
 import { describe, it } from 'mocha';
 import { Assert } from '../../main/ts/api/Main';
-import * as fc from 'fast-check';
-import { Testable } from '@ephox/dispute';
-import { TestError } from '@ephox/bedrock-common';
-
-import * as chai from 'chai';
 
 const { tArray, tString } = Testable;
 
 describe('Assert.eq', () => {
   it('does not throw when assertion passes', () => {
     fc.assert(fc.property(fc.integer(), (i) => {
-      Assert.eq("blah", i, i);
+      Assert.eq('blah', i, i);
       return true;
     }));
 
     fc.assert(fc.property(fc.array(fc.string()), (xs) => {
-      Assert.eq("blah", xs, xs);
-      Assert.eq("blah", xs, xs.slice());
-      Assert.eq("blah", xs, xs.slice(), tArray(tString));
+      Assert.eq('blah', xs, xs);
+      Assert.eq('blah', xs, xs.slice());
+      Assert.eq('blah', xs, xs.slice(), tArray(tString));
       return true;
     }));
   });
 
   it('throws when assertion fails', () => {
     Assert.throws('throws', () => {
-      Assert.eq("blah", "a", "b");
+      Assert.eq('blah', 'a', 'b');
     });
   });
 
   it('throws a PprintAssertionError', () => {
     try {
-      Assert.eq("blah", "a", "b");
+      Assert.eq('blah', 'a', 'b');
     } catch (e) {
       const ee = e as TestError.PprintAssertionError;
       chai.assert.deepEqual(ee.message, 'blah');

--- a/modules/client/src/test/ts/TestLabelTest.ts
+++ b/modules/client/src/test/ts/TestLabelTest.ts
@@ -2,26 +2,26 @@ import * as fc from 'fast-check';
 import { TestLabel } from '../../main/ts/api/TestLabel';
 import { describe, it } from 'mocha';
 
-describe("TestLabel.asString", () => {
-  it("stringifies strings", () => {
+describe('TestLabel.asString', () => {
+  it('stringifies strings', () => {
     fc.assert(fc.property(fc.string(), (s) => TestLabel.asString(s) === s));
   });
 
-  it("stringifies () => strings", () => {
+  it('stringifies () => strings', () => {
     fc.assert(fc.property(fc.string(), (s) => TestLabel.asString(() => s) === s));
   });
 });
 
-describe("TestLabel.asStringOr", () => {
-  it("stringifies strings", () => {
+describe('TestLabel.asStringOr', () => {
+  it('stringifies strings', () => {
     fc.assert(fc.property(fc.string(), fc.string(), (a, b) => TestLabel.asStringOr(a, b) === a));
   });
 
-  it("defaults for null", () => {
+  it('defaults for null', () => {
     fc.assert(fc.property(fc.string(), (a) => TestLabel.asStringOr(null, a) === a));
   });
 
-  it("defaults for undefined", () => {
+  it('defaults for undefined', () => {
     fc.assert(fc.property(fc.string(), (a) => TestLabel.asStringOr(undefined, a) === a));
   });
 });

--- a/modules/common/.eslintrc.js
+++ b/modules/common/.eslintrc.js
@@ -6,11 +6,15 @@ module.exports =  {
     'plugin:@typescript-eslint/recommended',
   ],
   parserOptions:  {
-    sourceType:  'module',
+    sourceType: 'module',
   },
   rules:  {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-use-before-define": "off"
+    "@typescript-eslint/no-use-before-define": "off",
+
+    "object-shorthand": "error",
+    "quotes": [ "error", "single", { "allowTemplateLiterals": true } ],
+    "semi": "error"
   }
 };

--- a/modules/common/src/main/ts/api/Differ.ts
+++ b/modules/common/src/main/ts/api/Differ.ts
@@ -8,13 +8,13 @@ export const diffPrettyHtml = (text1: string, text2: string): string => {
     const prefix = (c.removed ? '<del style="background:#ffe6e6;">' : c.added ? '<ins style="background:#e6ffe6;">' : '<span>');
     const suffix = (c.removed ? '</del>' : c.added ? '</ins>' : '</span>');
     const texts = c.value;
-    const tz = texts.map((t) => prefix + htmlentities(t) + suffix + "<br />");
+    const tz = texts.map((t) => prefix + htmlentities(t) + suffix + '<br />');
     return tz.join('');
   });
   return lines.join('');
 };
 
-export const diffPrettyText = (text1: string, text2: string) => {
+export const diffPrettyText = (text1: string, text2: string): string => {
   const changes: ArrayChange<string>[] = JsDiff.diffArrays(text1.split('\n'), text2.split('\n'));
   const lines = changes.map((c) => {
     const prefix = (c.removed ? '-' : c.added ? '+' : ' ') + ' | ';

--- a/modules/common/src/main/ts/api/Reporter.ts
+++ b/modules/common/src/main/ts/api/Reporter.ts
@@ -111,7 +111,7 @@ const mkText = (e: TestError): string => {
   if (TestError.isHTMLDiffError(e)) {
     return htmlDiffAssertionErrorText(e);
   } else if (TestError.isPprintAssertionError(e)) {
-    return pprintAssertionText(e)
+    return pprintAssertionText(e);
   } else if (TestError.isAssertionError(e)) {
     return assertionErrorText(e);
   } else if (e.name && e.message) {

--- a/modules/common/src/test/ts/api/DifferTest.ts
+++ b/modules/common/src/test/ts/api/DifferTest.ts
@@ -2,25 +2,25 @@ import { assert } from 'chai';
 import { describe, it } from 'mocha';
 import * as Differ from '../../../main/ts/api/Differ';
 
-describe("Differ", () => {
-  it("does stuff", () => {
-    const text1 = "a\nx\ny\nc";
-    const text2 = "a\nb\nc";
+describe('Differ', () => {
+  it('does stuff', () => {
+    const text1 = 'a\nx\ny\nc';
+    const text2 = 'a\nb\nc';
 
     assert.deepEqual(Differ.diffPrettyText(text1, text2),
-      "  | a\n" +
-      "- | x\n" +
-      "- | y\n" +
-      "+ | b\n" +
-      "  | c"
+      '  | a\n' +
+      '- | x\n' +
+      '- | y\n' +
+      '+ | b\n' +
+      '  | c'
     );
 
     assert.deepEqual(Differ.diffPrettyHtml(text1, text2),
-      "<span>a</span><br />" +
-      "<del style=\"background:#ffe6e6;\">x</del><br />" +
-      "<del style=\"background:#ffe6e6;\">y</del><br />" +
-      "<ins style=\"background:#e6ffe6;\">b</ins><br />" +
-      "<span>c</span><br />"
+      '<span>a</span><br />' +
+      '<del style="background:#ffe6e6;">x</del><br />' +
+      '<del style="background:#ffe6e6;">y</del><br />' +
+      '<ins style="background:#e6ffe6;">b</ins><br />' +
+      '<span>c</span><br />'
     );
   });
 });

--- a/modules/common/src/test/ts/api/ReporterTest.ts
+++ b/modules/common/src/test/ts/api/ReporterTest.ts
@@ -15,7 +15,7 @@ function htmlAssertion() {
   return e;
 }
 
-describe("Reporter", () => {
+describe('Reporter', () => {
   it('Reports thrown js errors as html', () => {
     try {
       // noinspection ExceptionCaughtLocallyJS
@@ -23,7 +23,7 @@ describe("Reporter", () => {
     } catch (e) {
       const actual = Reporter.html(LoggedError.loggedError(e, []));
       const expected = 'Error: blarg&lt;span&gt;\n\nLogs:\n';
-      assert.deepEqual(actual, expected, 'Error message')
+      assert.deepEqual(actual, expected, 'Error message');
     }
   });
 
@@ -37,7 +37,7 @@ describe("Reporter", () => {
       ]));
       const expected = 'Error: blarg&lt;span&gt;\n\nLogs:\n' +
         'PprintAssertionError: Checking attribute: &quot;height&quot; of &lt;iframe src=&quot;http://www.example.com/&quot; width=&quot;200&quot; height=&quot;200&quot;&gt;&lt;/iframe&gt;';
-      assert.deepEqual(actual, expected, 'Error message')
+      assert.deepEqual(actual, expected, 'Error message');
     }
   });
 
@@ -48,7 +48,7 @@ describe("Reporter", () => {
     } catch (e) {
       const actual = Reporter.text(LoggedError.loggedError(e, []));
       const expected = 'Error: blarg<span>\n\nLogs:\n';
-      assert.deepEqual(actual, expected, 'Error message')
+      assert.deepEqual(actual, expected, 'Error message');
     }
   });
 
@@ -67,7 +67,7 @@ describe("Reporter", () => {
         'HTML Diff: <ins>blah</ins><del>hello</del>&quot;hello&quot;&lt;span&gt;\n' +
         '\n' +
         'Logs:\n';
-      assert.deepEqual(actual, expected, 'Error message')
+      assert.deepEqual(actual, expected, 'Error message');
     }
   });
 
@@ -85,7 +85,7 @@ describe("Reporter", () => {
         'HTML Diff: <ins>blah</ins><del>hello</del>"hello"<span>\n' +
         '\n' +
         'Logs:\n';
-      assert.deepEqual(actual, expected, 'Error message')
+      assert.deepEqual(actual, expected, 'Error message');
     }
   });
 

--- a/modules/common/src/test/ts/api/TestErrorTest.ts
+++ b/modules/common/src/test/ts/api/TestErrorTest.ts
@@ -2,8 +2,8 @@ import { describe, it } from 'mocha';
 import { assert } from 'chai';
 import * as TestError from '../../../main/ts/api/TestError';
 
-describe("PprintAssertionError.toString()", () => {
-  it("includes a diff", () => {
+describe('PprintAssertionError.toString()', () => {
+  it('includes a diff', () => {
     const actual = TestError.pprintAssertionError('message', 'b', 'a').toString();
     const expected =
       'Test failure: message\n' +

--- a/modules/runner/.eslintrc.js
+++ b/modules/runner/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports =  {
   root: true,
   parser:  '@typescript-eslint/parser',
-  plugins: ["@typescript-eslint"],
+  plugins: ['@typescript-eslint'],
   extends:  [
     'plugin:@typescript-eslint/recommended',
   ],
@@ -9,11 +9,15 @@ module.exports =  {
     sourceType:  'module',
   },
   rules:  {
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-empty-function": "off"
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-empty-function': 'off',
+
+    'object-shorthand': 'error',
+    'quotes': [ 'error', 'single', { 'allowTemplateLiterals': true } ],
+    'semi': 'error'
   },
-  "env": {
-    "browser": true,
+  env: {
+    browser: true,
   }
 };

--- a/modules/runner/src/main/ts/core/Runner.ts
+++ b/modules/runner/src/main/ts/core/Runner.ts
@@ -7,12 +7,17 @@ import { TestData } from './TestTypes';
 import { UrlParams } from './UrlParams';
 import { noop } from './Utils';
 
+export interface Runner {
+  readonly init: (onSuccess: (data: HarnessResponse) => void, onError: (e: any) => void) => void;
+  readonly run: (chunk: number, retries: number, timeout: number, stopOnFailure: boolean) => void;
+}
+
 // 5sec interval for the server to know the client hasn't disconnected
 // Note: The interval needs to be less than 10secs, otherwise the server will disconnect.
 //       See `Controller.ts` in the server.
 const KEEP_ALIVE_INTERVAL = 5000;
 
-export const Runner = (globalTests: TestData[], params: UrlParams, callbacks: Callbacks, reporter: Reporter, ui: Ui) => {
+export const Runner = (globalTests: TestData[], params: UrlParams, callbacks: Callbacks, reporter: Reporter, ui: Ui): Runner => {
   const actions = Actions(params.session);
 
   const withSum = (action: (offset: number, failed: number, retry?: number) => void, offset = 0, failedOffset = 0) => (retry?: number) => {
@@ -113,5 +118,5 @@ export const Runner = (globalTests: TestData[], params: UrlParams, callbacks: Ca
   return {
     init,
     run
-  }
+  };
 };

--- a/modules/runner/src/main/ts/reporter/Callbacks.ts
+++ b/modules/runner/src/main/ts/reporter/Callbacks.ts
@@ -17,7 +17,7 @@ const Global: any = window;
 const sendJson = (url: string, data: any, onSuccess: onSuccessCallback = noop, onError: onErrorCallback = noop): void => {
   $.ajax({
     method: 'post',
-    url: url,
+    url,
     dataType: 'json',
     success: onSuccess,
     error: onError,
@@ -28,27 +28,27 @@ const sendJson = (url: string, data: any, onSuccess: onSuccessCallback = noop, o
 export const Callbacks = (): Callbacks => {
   const sendKeepAlive = (session: string, onSuccess: onSuccessCallback, onError: onErrorCallback): void => {
     sendJson('/tests/alive', {
-      session: session,
+      session,
     }, onSuccess, onError);
   };
 
   const sendTestStart = (session: string, totalTests: number, file: string, name: string, onSuccess: onSuccessCallback, onError: onErrorCallback): void => {
     sendJson('/tests/start', {
       totalTests,
-      session: session,
-      file: file,
-      name: name,
+      session,
+      file,
+      name,
     }, onSuccess, onError);
   };
 
   const sendTestResult = (session: string, file: string, name: string, passed: boolean, time: string, error: string | null, onSuccess: onSuccessCallback, onError: onErrorCallback): void => {
     sendJson('/tests/result', {
-      session: session,
-      file: file,
-      name: name,
-      passed: passed,
-      time: time,
-      error: error,
+      session,
+      file,
+      name,
+      passed,
+      time,
+      error,
     }, onSuccess, onError);
   };
 
@@ -57,7 +57,7 @@ export const Callbacks = (): Callbacks => {
     const getCoverage = (): Record<string, any> => typeof Global.__coverage__ === 'undefined' ? {} : Global.__coverage__;
 
     sendJson('/tests/done', {
-      session: session,
+      session,
       coverage: getCoverage(),
     }, onSuccess, onError);
   };

--- a/modules/runner/src/main/ts/ui/Ui.ts
+++ b/modules/runner/src/main/ts/ui/Ui.ts
@@ -98,7 +98,7 @@ export const Ui = (container: JQuery<HTMLElement>): Ui => {
       start,
       pass,
       fail
-    }
+    };
   };
 
   const error = (e: any) => {
@@ -119,5 +119,5 @@ export const Ui = (container: JQuery<HTMLElement>): Ui => {
     hideRetry: () => retryBtn.show(),
     showRetry: () => retryBtn.show(),
     setStopOnFailure
-  }
+  };
 };

--- a/modules/runner/src/test/ts/core/UtilsTest.ts
+++ b/modules/runner/src/test/ts/core/UtilsTest.ts
@@ -12,13 +12,13 @@ describe('Utils.makeQueryParams', () => {
   it('should always include a session, offset and failed params if offset > 0', () => {
     fc.assert(fc.property(fc.hexaString(), fc.integer(1, 1000), fc.nat(), (session, offset, failed) => {
       assert.equal(Utils.makeQueryParams(session, offset, failed, 0), '?session=' + session + '&offset=' + offset + '&failed=' + failed);
-    }))
+    }));
   });
 
   it('should always include a session, offset and failed params if retries > 0', () => {
     fc.assert(fc.property(fc.hexaString(), fc.integer(1, 1000), fc.nat(), (session, retries, failed) => {
       assert.equal(Utils.makeQueryParams(session, 0, failed, retries), '?session=' + session + '&offset=' + 0 + '&failed=' + failed + '&retry=' + retries);
-    }))
+    }));
   });
 
   it('should exclude retries if 0', () => {
@@ -47,5 +47,5 @@ describe('Utils.formatElapsedTime', () => {
     const result = Utils.formatElapsedTime(now, now);
     assert.equal(parseFloat(result), 0.0);
     assert.equal(result, '0.000s');
-  })
+  });
 });

--- a/modules/runner/src/test/ts/reporter/ReporterTest.ts
+++ b/modules/runner/src/test/ts/reporter/ReporterTest.ts
@@ -80,7 +80,7 @@ describe('Reporter.test', () => {
 
         assert.equal(endTestData.length, 0);
         assert.deepEqual(reporter.summary(), {
-          offset: offset,
+          offset,
           passed: offset,
           failed: 0
         }, 'Summary has no passed or failed tests');
@@ -97,7 +97,7 @@ describe('Reporter.test', () => {
       test.start(() => {
         test.pass(() => {
           assert.equal(endTestData.length, 1);
-          const data = endTestData[ 0 ];
+          const data = endTestData[0];
           assert.equal(data.session, sessionId);
           assert.equal(data.file, fileName + 'Test.ts');
           assert.equal(data.name, testName);
@@ -105,7 +105,7 @@ describe('Reporter.test', () => {
           assert.isString(data.time);
 
           assert.deepEqual(reporter.summary(), {
-            offset: offset,
+            offset,
             passed: offset + 1,
             failed: 0
           }, 'Summary has one passed test');
@@ -136,7 +136,7 @@ describe('Reporter.test', () => {
           assert.equal(data.error, 'Error: Failed\n\nLogs:\n');
 
           assert.deepEqual(reporter.summary(), {
-            offset: offset,
+            offset,
             passed: offset,
             failed: 1
           }, 'Summary has one failed test');
@@ -151,5 +151,5 @@ describe('Reporter.test', () => {
   it('should report done', () => {
     reporter.done();
     assert.isTrue(doneCalled);
-  })
+  });
 });

--- a/modules/sample/.eslintrc.js
+++ b/modules/sample/.eslintrc.js
@@ -1,24 +1,29 @@
 module.exports = {
   root: true,
-  extends: "eslint:recommended",
+  parser:  '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends:  [
+    'plugin:@typescript-eslint/recommended'
+  ],
   parserOptions: {
-    ecmaVersion: 11,
-    sourceType: "module",
-    ecmaFeatures: {
-      impliedStrict: true
-    }
+    sourceType: 'module',
   },
   rules: {
-    "curly": ["error", "multi-line"],
-    "object-curly-spacing": "off",
-    "array-bracket-spacing": "off",
-    "space-before-function-paren": "off",
-    "no-trailing-spaces": "off",
-    "indent": ["error", 2],
-    "max-len": "off",
-    "no-prototype-builtins": "off"
+    'curly': ['error', 'multi-line'],
+    'object-curly-spacing': 'off',
+    'array-bracket-spacing': 'off',
+    'space-before-function-paren': 'off',
+    'no-trailing-spaces': 'off',
+    'indent': ['error', 2],
+    'max-len': 'off',
+    'no-prototype-builtins': 'off',
+    'object-shorthand': 'error',
+    'quotes': [ 'error', 'single', { 'allowTemplateLiterals': true } ],
+    'semi': 'error',
+
+    '@typescript-eslint/no-empty-function': 'off',
   },
-  "env": {
-    "node": true
+  env: {
+    browser: true
   }
 };

--- a/modules/sample/src/test/js/client/SyncPassTest.js
+++ b/modules/sample/src/test/js/client/SyncPassTest.js
@@ -1,4 +1,4 @@
-import { UnitTest, assert } from '@ephox/bedrock-client'
+import { UnitTest, assert } from '@ephox/bedrock-client';
 
 UnitTest.test('SyncPass Test', function () {
   assert.eq(1, 1);

--- a/modules/sample/src/test/ts/client/AsyncFailWithLogsTest.ts
+++ b/modules/sample/src/test/ts/client/AsyncFailWithLogsTest.ts
@@ -1,4 +1,4 @@
-import { UnitTest } from '@ephox/bedrock-client'
+import { UnitTest } from '@ephox/bedrock-client';
 
 UnitTest.asyncTest('AsyncFail with Logs Test', (success, failure) => {
 

--- a/modules/sample/src/test/ts/client/ClipboardTest.ts
+++ b/modules/sample/src/test/ts/client/ClipboardTest.ts
@@ -1,10 +1,10 @@
-import { UnitTest } from '@ephox/bedrock-client'
+import { UnitTest } from '@ephox/bedrock-client';
 
 UnitTest.asynctest('Clipboard Test', (success, failure) => {
 
   if (window.fetch === undefined) return failure('This sample only runs on Chrome');
 
-  var importClipboard = function (fileName) {
+  const importClipboard = function (fileName) {
     return fetch('/clipboard', {
       method: 'POST',
       headers: {
@@ -17,7 +17,7 @@ UnitTest.asynctest('Clipboard Test', (success, failure) => {
     });
   };
 
-  var pasteInto = function (elm) {
+  const pasteInto = function (elm) {
     return fetch('/keys', {
       method: 'POST',
       headers: {
@@ -33,7 +33,7 @@ UnitTest.asynctest('Clipboard Test', (success, failure) => {
     });
   };
 
-  var assert = function () {
+  const assert = function () {
     return new Promise(function (done) {
       setTimeout(function() {
         alert(body.innerHTML);
@@ -42,7 +42,7 @@ UnitTest.asynctest('Clipboard Test', (success, failure) => {
     });
   };
 
-  var body = document.createElement('div');
+  const body = document.createElement('div');
   body.id = 'test';
   body.contentEditable = 'true';
   document.body.appendChild(body);

--- a/modules/sample/src/test/ts/client/IFramePassTest.ts
+++ b/modules/sample/src/test/ts/client/IFramePassTest.ts
@@ -1,29 +1,29 @@
-import { UnitTest, assert } from '@ephox/bedrock-client'
+import { UnitTest, assert } from '@ephox/bedrock-client';
 
 UnitTest.asyncTest('IFrame Test', (success, failure) => {
 
   /*
     * This frame will get sent keyboard events to its content editable body
     */
-  var iframe1 = document.createElement('iframe');
+  const iframe1 = document.createElement('iframe');
   iframe1.setAttribute('class', 'iframe-keyboard');
 
   /*
     * This textarea will get sent keyboard events
     */
-  var textarea = document.createElement('textarea');
+  const textarea = document.createElement('textarea');
 
 
   /*
     * This frame will get sent mouse events to its select inside
     */
-  var iframe2 = document.createElement('iframe');
+  const iframe2 = document.createElement('iframe');
   iframe2.setAttribute('class', 'iframe-mouse');
 
   /*
     * This button will get sent mouse events
     */
-  var button = document.createElement('button');
+  const button = document.createElement('button');
   button.innerHTML = 'Click me';
   button.setAttribute('class', 'button-mouse');
   button.addEventListener('click', function () {
@@ -32,8 +32,8 @@ UnitTest.asyncTest('IFrame Test', (success, failure) => {
   });
 
 
-  var post = function (url, data, onSuccess, onFailure) {
-    var request = new XMLHttpRequest();
+  const post = function (url, data, onSuccess, onFailure) {
+    const request = new XMLHttpRequest();
     request.open('POST', url, true);
     request.onload = function () {
       try {
@@ -53,20 +53,20 @@ UnitTest.asyncTest('IFrame Test', (success, failure) => {
   };
 
 
-  var sendText = function (selector, text, onSuccess, onFailure) {
-    post('/keys', { selector: selector, keys: [ { text: text } ] }, onSuccess, onFailure);
+  const sendText = function (selector, text, onSuccess, onFailure) {
+    post('/keys', { selector, keys: [ { text } ] }, onSuccess, onFailure);
   };
 
-  var sendMouse = function (selector, type, onSuccess, onFailure) {
-    post('/mouse', { selector: selector, type: type }, onSuccess, onFailure);
+  const sendMouse = function (selector, type, onSuccess, onFailure) {
+    post('/mouse', { selector, type }, onSuccess, onFailure);
   };
 
 
-  var loadContentIntoFrame = function (fr, content, onSuccess, onFailure) {
-    var listener = function () {
+  const loadContentIntoFrame = function (fr, content, onSuccess, onFailure) {
+    const listener = function () {
       fr.removeEventListener('load', listener);
       try {
-        var doc = fr.contentWindow.document;
+        const doc = fr.contentWindow.document;
         doc.open('text/html', 'replace');
         doc.writeln(content);
         doc.close();

--- a/modules/sample/src/test/ts/client/SyncFailTest.ts
+++ b/modules/sample/src/test/ts/client/SyncFailTest.ts
@@ -1,4 +1,4 @@
-import { UnitTest, assert } from '@ephox/bedrock-client'
+import { UnitTest, assert } from '@ephox/bedrock-client';
 
 UnitTest.test('SyncFail Test', () => {
   assert.eq(1, 2);

--- a/modules/sample/src/test/ts/client/SyncPassTest.ts
+++ b/modules/sample/src/test/ts/client/SyncPassTest.ts
@@ -1,6 +1,5 @@
-import { UnitTest, assert } from '@ephox/bedrock-client'
+import { UnitTest, assert } from '@ephox/bedrock-client';
 
 UnitTest.test('SyncPass Test', () => {
   assert.eq(1, 1);
-
 });

--- a/modules/sample/src/test/ts/client/TabbingPassTest.ts
+++ b/modules/sample/src/test/ts/client/TabbingPassTest.ts
@@ -1,10 +1,10 @@
-import { UnitTest, assert } from '@ephox/bedrock-client'
+import { UnitTest, assert } from '@ephox/bedrock-client';
 
 UnitTest.asyncTest('Tabbing Test', (success, failure) => {
-  var input1 = document.createElement('input');
+  const input1 = document.createElement('input');
   input1.classList.add('input-1');
 
-  var input2 = document.createElement('input');
+  const input2 = document.createElement('input');
   input2.classList.add('input-2');
 
   document.body.appendChild(input1);
@@ -13,8 +13,8 @@ UnitTest.asyncTest('Tabbing Test', (success, failure) => {
   input1.focus();
 
   // Dupe with IFramePassTest.ts
-  var post = function (url, data, onSuccess, onFailure) {
-    var request = new XMLHttpRequest();
+  const post = function (url: string, data: any, onSuccess: () => void, onFailure: (err?: Error) => void) {
+    const request = new XMLHttpRequest();
     request.open('POST', url, true);
     request.onload = function () {
       try {

--- a/modules/sample/src/test/ts/client/TsxPassTest.tsx
+++ b/modules/sample/src/test/ts/client/TsxPassTest.tsx
@@ -1,4 +1,4 @@
-import { UnitTest, assert } from '@ephox/bedrock-client'
+import { UnitTest, assert } from '@ephox/bedrock-client';
 
 UnitTest.test('SyncPass Test', () => {
   const React = {

--- a/modules/server/.eslintrc.js
+++ b/modules/server/.eslintrc.js
@@ -1,32 +1,35 @@
 module.exports = {
   root: true,
   parser:  '@typescript-eslint/parser',
-  plugins: ["@typescript-eslint"],
+  plugins: ['@typescript-eslint'],
   extends:  [
-    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended'
   ],
-  'env': {
-    'commonjs': true,
-    'es6': true,
-    "node": true
+  env: {
+    commonjs: true,
+    es6: true,
+    node: true
   },
-  'globals': {
+  globals: {},
+  parserOptions: {
+    sourceType: 'module'
   },
-  'parserOptions': {
-    'sourceType': 'module',
-  },
-  'rules': {
-    "max-len": "off",
-    "space-before-function-paren": ["error", "always"],
-    "comma-dangle": ["error", "never"],
-    "indent": ["error", 2],
-    "require-jsdoc": "off",
-    "prefer-promise-reject-errors": "off",
-    "prefer-spread": "off",
-    "no-prototype-builtins": "off",
+  rules: {
+    'max-len': 'off',
+    'space-before-function-paren': ['error', 'always'],
+    'comma-dangle': ['error', 'never'],
+    'indent': ['error', 2],
+    'require-jsdoc': 'off',
+    'prefer-promise-reject-errors': 'off',
+    'prefer-spread': 'off',
+    'no-prototype-builtins': 'off',
+    'object-shorthand': 'error',
+    'quotes': [ 'error', 'single', { 'allowTemplateLiterals': true } ],
+    'semi': 'error',
 
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-unused-vars": "off"
-  },
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': [ 'error', { 'allowArgumentsExplicitlyTypedAsAny': true } ]
+  }
 };

--- a/modules/server/src/main/ts/BedrockAuto.ts
+++ b/modules/server/src/main/ts/BedrockAuto.ts
@@ -11,7 +11,7 @@ import { ExitCodes } from './bedrock/util/ExitCodes';
 import * as ConsoleReporter from './bedrock/core/ConsoleReporter';
 import { TestResults } from './bedrock/server/Controller';
 
-export const go = (settings: BedrockAutoSettings) => {
+export const go = (settings: BedrockAutoSettings): void => {
   const master = DriverMaster.create();
 
   const isPhantom = settings.browser === 'phantomjs';
@@ -35,8 +35,8 @@ export const go = (settings: BedrockAutoSettings) => {
         basedir: settings.basedir,
         testfiles: settings.testfiles,
         driver: Attempt.passed(webdriver),
-        master: master,
-        runner: runner,
+        master,
+        runner,
         loglevel: settings.loglevel,
         customRoutes: settings.customRoutes,
         stickyFirstSession: true,

--- a/modules/server/src/main/ts/BedrockCli.ts
+++ b/modules/server/src/main/ts/BedrockCli.ts
@@ -7,7 +7,7 @@ type Program = {
   mode: 'forAuto' | 'forManual' | 'forFramework';
 }
 
-export const run = (program: Program, directories: { current: string; bin: string }) => {
+export const run = (program: Program, directories: { current: string; bin: string }): void => {
   if (Clis[program.mode] === undefined) {
     throw new Error('Bedrock mode not known: ' + program.mode);
   }

--- a/modules/server/src/main/ts/BedrockFramework.ts
+++ b/modules/server/src/main/ts/BedrockFramework.ts
@@ -10,7 +10,7 @@ import * as Lifecycle from './bedrock/core/Lifecycle';
 import { BedrockFrameworkSettings } from './bedrock/core/Settings';
 
 /* eslint-disable no-undef */
-export const go = (settings: BedrockFrameworkSettings) => {
+export const go = (settings: BedrockFrameworkSettings): void => {
   const master = DriverMaster.create();
 
   const runner = PageRoutes.generate(settings.projectdir, settings.basedir);
@@ -27,8 +27,8 @@ export const go = (settings: BedrockFrameworkSettings) => {
       basedir: settings.basedir,
       driver: Attempt.passed(webdriver),
       testfiles: [],
-      master: master,
-      runner: runner,
+      master,
+      runner,
       loglevel: settings.loglevel,
       customRoutes: settings.customRoutes,
       stickyFirstSession: true,

--- a/modules/server/src/main/ts/BedrockManual.ts
+++ b/modules/server/src/main/ts/BedrockManual.ts
@@ -5,7 +5,7 @@ import * as Webpack from './bedrock/compiler/Webpack';
 import { BedrockSettings } from './bedrock/core/Settings';
 import { ExitCodes } from './bedrock/util/ExitCodes';
 
-export const go = (settings: BedrockSettings) => {
+export const go = (settings: BedrockSettings): void => {
   const basePage = 'src/resources/html/bedrock.html';
   const routes = RunnerRoutes.generate('manual', settings.projectdir, settings.basedir, settings.config, settings.bundler, settings.testfiles, settings.chunk, 0, settings.singleTimeout, true, basePage, settings.coverage);
 
@@ -19,7 +19,7 @@ export const go = (settings: BedrockSettings) => {
       // There is no driver for manual mode.
       driver: Attempt.failed('There is no webdriver for manual mode'),
       master: null, // there is no need for master,
-      runner: runner,
+      runner,
       loglevel: settings.loglevel,
       customRoutes: settings.customRoutes,
       config: settings.config,

--- a/modules/server/src/main/ts/bedrock/auto/Driver.ts
+++ b/modules/server/src/main/ts/bedrock/auto/Driver.ts
@@ -71,8 +71,8 @@ const addArguments = (capabilities: Record<string, any>, name: string, args: str
 const getOptions = (port: number, browserName: string, browserFamily: string, settings: DriverSettings): Options => {
   const options = {
     path: '/',
-    port: port,
-    logLevel: 'silent' as 'silent',
+    port,
+    logLevel: 'silent' as const,
     capabilities: {
       browserName: browserFamily
     }
@@ -102,7 +102,7 @@ const getOptions = (port: number, browserName: string, browserFamily: string, se
       'devtools.debugger.remote-enabled': true,
       'devtools.debugger.prompt-connection': false,
       'devtools.chrome.enabled': true
-    }
+    };
   } else if (browserName === 'chrome-headless') {
     addArguments(caps, 'goog:chromeOptions', [ '--headless', '--remote-debugging-port=' + settings.debuggingPort ]);
     if (settings.useSandboxForHeadless) {
@@ -141,7 +141,7 @@ const focusBrowser = (browserName: string, settings: DriverSettings) => {
   }
 };
 
-const setupShutdown = (driver: webdriverio.BrowserObject, driverApi: DriverLoader.DriverAPI, shutdownDelay: number = 0): (immediate?: boolean) => Promise<void> => {
+const setupShutdown = (driver: webdriverio.BrowserObject, driverApi: DriverLoader.DriverAPI, shutdownDelay = 0): (immediate?: boolean) => Promise<void> => {
   const driverShutdown = (immediate?: boolean) => {
     try {
       if (immediate) {

--- a/modules/server/src/main/ts/bedrock/auto/DriverLoader.ts
+++ b/modules/server/src/main/ts/bedrock/auto/DriverLoader.ts
@@ -96,7 +96,7 @@ export const loadDriver = (browserName: string): DriverAPI => {
   }
 };
 
-export const waitForAlive = (proc: ChildProcess, port: number, timeout = 30000) => {
+export const waitForAlive = (proc: ChildProcess, port: number, timeout = 30000): Promise<void> => {
   const url = 'http://localhost:' + port + '/status';
   const start = Date.now();
   return new Promise<void>((resolve, reject) => {
@@ -149,10 +149,10 @@ export const waitForAlive = (proc: ChildProcess, port: number, timeout = 30000) 
 
     // Start listening for the server to be ready
     checkServerStatus();
-  })
+  });
 };
 
-export const startAndWaitForAlive = (driverApi: DriverAPI, port: number, timeout = 30000) => {
+export const startAndWaitForAlive = (driverApi: DriverAPI, port: number, timeout = 30000): Promise<void> => {
   // Start the driver
   const driverProc = driverApi.start(['--port=' + port]);
   // Wait for it to be alive

--- a/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
+++ b/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
@@ -68,7 +68,7 @@ export const configTo = (defaultValue: string): ClOption => {
     name: 'config',
     alias: 'c',
     type: String,
-    defaultValue: defaultValue,
+    defaultValue,
     description: 'The location of the typescript config file',
     validate: Extraction.any
   };
@@ -258,7 +258,6 @@ export const wipeBrowserCache: ClOption = {
 };
 
 // TODO: what is this setting?
-// eslint-disable-next-line camelcase,@typescript-eslint/camelcase
 export const stopOnFailure__hidden: ClOption = {
   name: 'stopOnFailure',
   description: 'Stop on failure',

--- a/modules/server/src/main/ts/bedrock/cli/Cli.ts
+++ b/modules/server/src/main/ts/bedrock/cli/Cli.ts
@@ -22,7 +22,7 @@ const parseCommandLine = (definitions: commandLineArgs.OptionDefinition[], argv:
   }
 };
 
-export const extract = (command: string, desc: string, definitions: ClOption[], argv: string[]) => {
+export const extract = (command: string, desc: string, definitions: ClOption[], argv: string[]): Attempt<CliError, CommandLineOptions> => {
   const parsed = parseCommandLine(definitions, argv);
 
   Attempt.cata(parsed, () => {
@@ -45,7 +45,7 @@ export const extract = (command: string, desc: string, definitions: ClOption[], 
 
   return Attempt.cata<string[], CommandLineOptions, Attempt<CliError, CommandLineOptions>>(extracted, (errs) => {
     return Attempt.failed({
-      command: command,
+      command,
       errors: errs,
       usage: CliUsage.generateUsage(command, desc, definitions)
     });

--- a/modules/server/src/main/ts/bedrock/cli/Clis.ts
+++ b/modules/server/src/main/ts/bedrock/cli/Clis.ts
@@ -23,7 +23,7 @@ const commonOptions = (directories: Directories) => {
   ];
 };
 
-export const forAuto = (directories: Directories, argv: string[] = process.argv) => {
+export const forAuto = (directories: Directories, argv: string[] = process.argv): Attempt<cli.CliError, BedrockAutoSettings> => {
   return cli.extract('bedrock-auto', 'Use a Webdriver to launch a browser and run tests against it', commonOptions(directories).concat([
     ClOptions.browser,
     ClOptions.config,
@@ -44,7 +44,7 @@ export const forAuto = (directories: Directories, argv: string[] = process.argv)
   ]), argv) as Attempt<cli.CliError, BedrockAutoSettings>;
 };
 
-export const forManual = (directories: Directories, argv: string[] = process.argv) => {
+export const forManual = (directories: Directories, argv: string[] = process.argv): Attempt<cli.CliError, BedrockSettings> => {
   return cli.extract('bedrock', 'Launch a testing process on a localhost port and allow the user to navigate to it in any browser', commonOptions(directories).concat([
     ClOptions.stopOnFailure__hidden,
     ClOptions.config,
@@ -56,7 +56,7 @@ export const forManual = (directories: Directories, argv: string[] = process.arg
   ]), argv) as Attempt<cli.CliError, BedrockSettings>;
 };
 
-export const forFramework = (directories: Directories, argv: string[] = process.argv) => {
+export const forFramework = (directories: Directories, argv: string[] = process.argv): Attempt<cli.CliError, BedrockFrameworkSettings> => {
   return cli.extract('bedrock-framework', 'Load bedrock against a specific page using a framework', commonOptions(directories).concat([
     ClOptions.stopOnFailure,
     ClOptions.name,
@@ -68,7 +68,7 @@ export const forFramework = (directories: Directories, argv: string[] = process.
   ]), argv) as Attempt<cli.CliError, BedrockFrameworkSettings>;
 };
 
-export const logAndExit = (errs: cli.CliError) => {
+export const logAndExit = (errs: cli.CliError): void => {
   console.error('\n****\nError while processing command line for ' + errs.command);
   const messages = errs.errors.join('\n');
   console.error(messages);

--- a/modules/server/src/main/ts/bedrock/cli/Hud.ts
+++ b/modules/server/src/main/ts/bedrock/cli/Hud.ts
@@ -1,16 +1,21 @@
 import * as readline from 'readline';
 
-type ResultData = {
-  done: boolean;
-  id: string;
-  numFailed: number;
-  numPassed: number;
-  test?: string;
-  totalFiles?: number;
-  totalTests?: number;
+interface ResultData {
+  readonly done: boolean;
+  readonly id: string;
+  readonly numFailed: number;
+  readonly numPassed: number;
+  readonly test?: string;
+  readonly totalFiles?: number;
+  readonly totalTests?: number;
 }
 
-export const create = (testfiles: string[], loglevel: 'simple' | 'advanced') => {
+export interface Hud {
+  readonly update: (data: ResultData) => Promise<void>;
+  readonly complete: () => Promise<void>;
+}
+
+export const create = (testfiles: string[], loglevel: 'simple' | 'advanced'): Hud => {
   let started = false;
 
   const stream = process.stdout;
@@ -25,7 +30,7 @@ export const create = (testfiles: string[], loglevel: 'simple' | 'advanced') => 
       ', Failed: ' + numFailed + ' ... ' + '\n'
     );
     readline.clearLine(stream, 1);
-    return Promise.resolve({});
+    return Promise.resolve();
   };
 
   const advUpdate = (data: ResultData) => {
@@ -44,12 +49,12 @@ export const create = (testfiles: string[], loglevel: 'simple' | 'advanced') => 
   };
 
   const complete = () => {
-    return Promise.resolve({});
+    return Promise.resolve();
   };
 
   const basicUpdate = (data: ResultData) => {
     stream.write('.');
-    return Promise.resolve({});
+    return Promise.resolve();
   };
 
   const supportsAdvanced = (() => {

--- a/modules/server/src/main/ts/bedrock/cli/Validation.ts
+++ b/modules/server/src/main/ts/bedrock/cli/Validation.ts
@@ -21,7 +21,7 @@ const validateRequired = (defn: ClOption, settings: CommandLineOptions): Attempt
   ]) : Attempt.passed(defn);
 };
 
-export const scanRequired = (definitions: ClOption[], settings: CommandLineOptions) => {
+export const scanRequired = (definitions: ClOption[], settings: CommandLineOptions): Attempt<string[], CommandLineOptions> => {
   const requiredInfo = definitions.map((defn) => {
     return validateRequired(defn, settings);
   });

--- a/modules/server/src/main/ts/bedrock/compiler/Compiler.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Compiler.ts
@@ -1,7 +1,11 @@
 import * as fs from 'fs';
 import * as Webpack from '../compiler/Webpack';
 
-export const compile = (tsConfigFile: string, scratchDir: string, basedir: string, exitOnCompileError: boolean, files: string[], coverage: string[]) => {
+export interface Compiler {
+  readonly generate: () => Promise<Buffer | string>;
+}
+
+export const compile = (tsConfigFile: string, scratchDir: string, basedir: string, exitOnCompileError: boolean, files: string[], coverage: string[]): Compiler => {
   const getCompileFunc = () => {
     return Webpack.compile;
   };

--- a/modules/server/src/main/ts/bedrock/compiler/Imports.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Imports.ts
@@ -125,7 +125,7 @@ ${imports}
 export {};`;
 };
 
-export const generateImports = (useRequire: boolean, scratchFile: string, srcFiles: string[]) => {
+export const generateImports = (useRequire: boolean, scratchFile: string, srcFiles: string[]): string => {
   if (hasTs(srcFiles)) {
     return generateImportsTs(useRequire, scratchFile, srcFiles);
   } else {

--- a/modules/server/src/main/ts/bedrock/compiler/Rollup.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Rollup.ts
@@ -7,7 +7,7 @@ import * as Imports from './Imports';
 import {ExitCodes} from '../util/ExitCodes';
 import * as FileUtils from '../util/FileUtils';
 
-export const compile = (tsConfigFile: string, scratchDir: string, exitOnCompileError: boolean, srcFiles: string[], success: (dest: string) => void) => {
+export const compile = (tsConfigFile: string, scratchDir: string, exitOnCompileError: boolean, srcFiles: string[], success: (dest: string) => void): void => {
   const scratchFile = path.join(scratchDir, 'compiled/tests.ts');
   const dest = path.join(scratchDir, 'compiled/tests.js');
 

--- a/modules/server/src/main/ts/bedrock/compiler/TsUtils.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/TsUtils.ts
@@ -1,5 +1,6 @@
-const hasTs = (srcFiles: string[]) => srcFiles.findIndex((fileName) => /(\.tsx?)$/.test(fileName)) !== -1;
+const hasTs = (srcFiles: string[]): boolean =>
+  srcFiles.findIndex((fileName) => /(\.tsx?)$/.test(fileName)) !== -1;
 
 export {
   hasTs
-}
+};

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -254,7 +254,7 @@ const getCompileInfo = (tsConfigFile: string, scratchDir: string, basedir: strin
 
 export const compile = (tsConfigFile: string, scratchDir: string, basedir: string, exitOnCompileError: boolean, srcFiles: string[], coverage: string[]): Promise<string> => {
   return getCompileInfo(tsConfigFile, scratchDir, basedir, false, srcFiles, coverage)
-    .then((compileInfo) => compileTests(compileInfo, exitOnCompileError, srcFiles))
+    .then((compileInfo) => compileTests(compileInfo, exitOnCompileError, srcFiles));
 };
 
 const isCompiledRequest = (request: { url: string }) => request.url.startsWith('/compiled/');

--- a/modules/server/src/main/ts/bedrock/core/Attempt.ts
+++ b/modules/server/src/main/ts/bedrock/core/Attempt.ts
@@ -1,5 +1,5 @@
 export interface Attempt<E, A> {
-  foldAttempt: <B>(onFailed: (e: E) => B, onPassed: (a: A) => B) => B;
+  readonly foldAttempt: <B>(onFailed: (e: E) => B, onPassed: (a: A) => B) => B;
 }
 
 const failed = <E, A>(err: E): Attempt<E, A> => {
@@ -18,19 +18,19 @@ const passed = <E, A>(value: A): Attempt<E, A> =>  {
   };
 };
 
-const cata = <E, A, B>(attempt: Attempt<E, A>, onFailed: (e: E) => B, onPassed: (a: A) => B) => {
+const cata = <E, A, B>(attempt: Attempt<E, A>, onFailed: (e: E) => B, onPassed: (a: A) => B): B => {
   return attempt.foldAttempt(onFailed, onPassed);
 };
 
-const bind = <E, A, B>(firstAttempt: Attempt<E, A>, f: (a: A) => Attempt<E, B>) => {
+const bind = <E, A, B>(firstAttempt: Attempt<E, A>, f: (a: A) => Attempt<E, B>): Attempt<E, B> => {
   return firstAttempt.foldAttempt<Attempt<E, B>>(failed, f);
 };
 
-const map = <E, A, B>(firstAttempt: Attempt<E, A>, f: (a: A) => B) => {
+const map = <E, A, B>(firstAttempt: Attempt<E, A>, f: (a: A) => B): Attempt<E, B> => {
   return firstAttempt.foldAttempt<Attempt<E, B>>(failed, (v) => passed(f(v)));
 };
 
-const list = <E, A>(firstAttempt: Attempt<E, A>, fs: Array<(a: A) => Attempt<E, A>>) => {
+const list = <E, A>(firstAttempt: Attempt<E, A>, fs: Array<(a: A) => Attempt<E, A>>): Attempt<E, A> => {
   return fs.reduce((rest, x) => {
     return bind(rest, x);
   }, firstAttempt);

--- a/modules/server/src/main/ts/bedrock/core/Coverage.ts
+++ b/modules/server/src/main/ts/bedrock/core/Coverage.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 const coverageDataDir = 'scratch';
 
-export const writeCoverageData = (data: Record<string, any>) => {
+export const writeCoverageData = (data: Record<string, any>): void => {
   if (Object.keys(data).length > 0) {
     const coverageDataFilePath = path.join(coverageDataDir, 'coverage.json');
 

--- a/modules/server/src/main/ts/bedrock/core/Lifecycle.ts
+++ b/modules/server/src/main/ts/bedrock/core/Lifecycle.ts
@@ -3,7 +3,7 @@ import { TestResult } from '../server/Controller';
 import { ExitCodes } from '../util/ExitCodes';
 import { Attempt } from './Attempt';
 
-export const shutdown = (promise: Promise<Attempt<string[], TestResult[]>>, driver: BrowserObject, done: () => Promise<any>, gruntDone: ((success: boolean) => void) | null, delayExiting: boolean) => {
+export const shutdown = (promise: Promise<Attempt<string[], TestResult[]>>, driver: BrowserObject, done: () => Promise<any>, gruntDone: ((success: boolean) => void) | null, delayExiting: boolean): Promise<void> => {
   const exitDelay = () => {
     // 17 minutes should be enough, if it's not we can make this configurable later.
     return delayExiting ? driver.pause(17 * 60 * 1000) : Promise.resolve();

--- a/modules/server/src/main/ts/bedrock/core/Reporter.ts
+++ b/modules/server/src/main/ts/bedrock/core/Reporter.ts
@@ -4,8 +4,8 @@ import { TestResults, TestResult } from '../server/Controller';
 import { Attempt } from './Attempt';
 
 export interface ReporterSettings {
-  name: string;
-  output: string;
+  readonly name: string;
+  readonly output: string;
 }
 
 const outputTime = (runnerTime: string) => {
@@ -28,11 +28,11 @@ export const splitCdatas =
       r = r + x;
       if (i < raw.length - 1) r = r + ']]';
       return r;
-    })
+    });
   };
 
 export const write = (settings: ReporterSettings) => {
-  return (data: TestResults) => {
+  return (data: TestResults): Promise<Attempt<string[], TestResult[]>> => {
     return new Promise<Attempt<string[], TestResult[]>>((resolve) => {
       const results = data.results;
       const time = (data.now - data.start) / 1000;
@@ -116,7 +116,7 @@ export const write = (settings: ReporterSettings) => {
   };
 };
 
-export const writePollExit = (settings: ReporterSettings, results: TestResults) => {
+export const writePollExit = (settings: ReporterSettings, results: TestResults): Promise<Attempt<string[], TestResult[]>> => {
   return write({
     name: settings.name,
     output: settings.output

--- a/modules/server/src/main/ts/bedrock/core/Settings.ts
+++ b/modules/server/src/main/ts/bedrock/core/Settings.ts
@@ -1,35 +1,35 @@
 export interface BedrockSettings {
-  basedir: string;
-  bundler: 'webpack' | 'rollup';
-  chunk: number;
-  config: string;
-  coverage: string[];
-  customRoutes: string;
-  gruntDone?: (success: boolean) => void;
-  loglevel: 'simple' | 'advanced';
-  name: string;
-  output: string;
-  overallTimeout: number;
-  projectdir: string;
-  singleTimeout: number;
-  testfiles: string[];
+  readonly basedir: string;
+  readonly bundler: 'webpack' | 'rollup';
+  readonly chunk: number;
+  readonly config: string;
+  readonly coverage: string[];
+  readonly customRoutes: string;
+  readonly gruntDone?: (success: boolean) => void;
+  readonly loglevel: 'simple' | 'advanced';
+  readonly name: string;
+  readonly output: string;
+  readonly overallTimeout: number;
+  readonly projectdir: string;
+  readonly singleTimeout: number;
+  readonly testfiles: string[];
 }
 
 export interface BedrockAutoSettings extends BedrockSettings {
-  browser: string;
-  debuggingPort: number;
-  delayExit: boolean;
-  retries: number;
-  skipResetMousePosition: boolean;
-  stopOnFailure: boolean;
-  useSandboxForHeadless: boolean;
-  wipeBrowserCache: boolean;
+  readonly browser: string;
+  readonly debuggingPort: number;
+  readonly delayExit: boolean;
+  readonly retries: number;
+  readonly skipResetMousePosition: boolean;
+  readonly stopOnFailure: boolean;
+  readonly useSandboxForHeadless: boolean;
+  readonly wipeBrowserCache: boolean;
 }
 
 export interface BedrockFrameworkSettings extends BedrockSettings {
-  browser: string;
-  debuggingPort: number;
-  framework: string;
-  page: string;
-  stopOnFailure: boolean;
+  readonly browser: string;
+  readonly debuggingPort: number;
+  readonly framework: string;
+  readonly page: string;
+  readonly stopOnFailure: boolean;
 }

--- a/modules/server/src/main/ts/bedrock/core/Version.ts
+++ b/modules/server/src/main/ts/bedrock/core/Version.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-export const get = () => 'v' + require('../../../../../package.json').version;
+export const get = (): string => 'v' + require('../../../../../package.json').version;

--- a/modules/server/src/main/ts/bedrock/server/Apis.ts
+++ b/modules/server/src/main/ts/bedrock/server/Apis.ts
@@ -1,16 +1,23 @@
 import { BrowserObject } from 'webdriverio';
-import * as KeyEffects from './KeyEffects';
-import * as EffectUtils from './EffectUtils';
-import * as MouseEffects from './MouseEffects';
-import * as ClipboardEffects from './ClipboardEffects';
-import * as Routes from './Routes';
-import * as Controller from './Controller';
 import { Attempt } from '../core/Attempt';
-import * as Waiter from '../util/Waiter';
 import * as Coverage from '../core/Coverage';
+import * as Waiter from '../util/Waiter';
+import * as ClipboardEffects from './ClipboardEffects';
+import * as Controller from './Controller';
 import { DriverMaster } from './DriverMaster';
+import * as EffectUtils from './EffectUtils';
+import * as KeyEffects from './KeyEffects';
+import * as MouseEffects from './MouseEffects';
+import * as Routes from './Routes';
 
 type Executor<D, T> = (driver: BrowserObject) => (data: D) => Promise<T>;
+
+export interface Apis {
+  readonly routers: Routes.Route[];
+  readonly markLoaded: () => void;
+  readonly enableHud: () => void;
+  readonly awaitDone: () => Promise<Controller.TestResults>;
+}
 
 // This is how long to wait before checking if the driver is ready again
 const pollRate = 200;
@@ -18,7 +25,7 @@ const pollRate = 200;
 const maxInvalidAttempts = 300;
 
 // TODO: Do not use files here.
-export const create = (master: DriverMaster, maybeDriver: Attempt<any, BrowserObject>, projectdir: string, basedir: string, stickyFirstSession: boolean, singleTimeout: number, overallTimeout: number, testfiles: string[], loglevel: 'simple' | 'advanced', resetMousePosition: boolean) => {
+export const create = (master: DriverMaster | null, maybeDriver: Attempt<any, BrowserObject>, projectdir: string, basedir: string, stickyFirstSession: boolean, singleTimeout: number, overallTimeout: number, testfiles: string[], loglevel: 'simple' | 'advanced', resetMousePosition: boolean): Apis => {
   let pageHasLoaded = false;
 
   // On IE, the webdriver seems to load the page before it's ready to start
@@ -110,7 +117,7 @@ export const create = (master: DriverMaster, maybeDriver: Attempt<any, BrowserOb
 
   return {
     routers,
-    markLoaded: markLoaded,
+    markLoaded,
     enableHud: c.enableHud,
     awaitDone: c.awaitDone
   };

--- a/modules/server/src/main/ts/bedrock/server/ClipboardEffects.ts
+++ b/modules/server/src/main/ts/bedrock/server/ClipboardEffects.ts
@@ -8,10 +8,10 @@ import { ExitCodes } from '../util/ExitCodes';
  }
  */
 export interface ClipboardData {
-  import: string;
+  readonly import: string;
 }
 
-const importClipboard = (basedir: string, clipboarddir: string, data: ClipboardData) => {
+const importClipboard = (basedir: string, clipboarddir: string, data: ClipboardData): Promise<void> => {
   const fileName = data.import;
   const fullPath = path.join(clipboarddir, fileName);
   const args = [
@@ -29,7 +29,7 @@ const importClipboard = (basedir: string, clipboarddir: string, data: ClipboardD
 };
 
 export const route = (basedir: string, clipboarddir: string) => {
-  return (data: ClipboardData) => {
+  return (data: ClipboardData): Promise<void> => {
     return importClipboard(basedir, clipboarddir, data);
   };
 };

--- a/modules/server/src/main/ts/bedrock/server/CustomRoutes.ts
+++ b/modules/server/src/main/ts/bedrock/server/CustomRoutes.ts
@@ -7,24 +7,24 @@ import * as Routes from './Routes';
 import * as FileUtils from '../util/FileUtils';
 
 interface CustomRequest {
-  headers?: Record<string, string>;
-  method?: string;
-  path?: string;
-  url?: string;
-  query?: Record<string, string>;
-  json?: any;
+  readonly headers?: Record<string, string>;
+  readonly method?: string;
+  readonly path?: string;
+  readonly url?: string;
+  readonly query?: Record<string, string>;
+  readonly json?: any;
 }
 
 interface CustomResponse {
-  status?: number;
-  headers?: Record<string, string>;
-  json?: any;
-  json_file?: string;
+  readonly status?: number;
+  readonly headers?: Record<string, string>;
+  readonly json?: any;
+  readonly json_file?: string;
 }
 
 export interface CustomRouteSpec {
-  request: CustomRequest;
-  response: CustomResponse;
+  readonly request: CustomRequest;
+  readonly response: CustomResponse;
 }
 
 const readRequestBody = (request: IncomingMessage, done: (body: string) => void) => {
@@ -144,7 +144,7 @@ const routers = (filePath: string) => {
   ];
 };
 
-export const create = (filePath: string) => {
+export const create = (filePath: string): { routers: Routes.Route[] } => {
   return {
     routers: routers(filePath)
   };

--- a/modules/server/src/main/ts/bedrock/server/DriverMaster.ts
+++ b/modules/server/src/main/ts/bedrock/server/DriverMaster.ts
@@ -3,16 +3,16 @@ import * as Waiter from '../util/Waiter';
 type Executor<T> = () => Promise<T>;
 
 interface QueueItem<T> {
-  f: Executor<T>;
-  label: string;
-  identifier: string;
+  readonly f: Executor<T>;
+  readonly label: string;
+  readonly identifier: string;
 }
 
 export interface DriverMaster {
-  waitForIdle: <T>(f: Executor<T>, label: string) => Promise<T>;
+  readonly waitForIdle: <T>(f: Executor<T>, label: string) => Promise<T>;
 }
 
-export const create = () => {
+export const create = (): DriverMaster => {
   let inUse = false;
 
   let queue: QueueItem<any>[] = [];
@@ -90,9 +90,9 @@ export const create = () => {
     } else {
       const identifier = label + '_' + new Date().getTime() + Math.floor(Math.random() * 10000);
       queue = queue.concat({
-        f: f,
-        label: label,
-        identifier: identifier
+        f,
+        label,
+        identifier
       });
       return doWaitForIdle(identifier, f, label, 100);
     }

--- a/modules/server/src/main/ts/bedrock/server/EffectUtils.ts
+++ b/modules/server/src/main/ts/bedrock/server/EffectUtils.ts
@@ -15,7 +15,7 @@ const frameSelected = (driver: BrowserObject, frame: string): () => Promise<bool
       }
       return false;
     });
-  }
+  };
 };
 
 const getTargetFromFrame = (driver: BrowserObject, selector: string) => {
@@ -59,7 +59,7 @@ const performActionOnMain = <T>(driver: BrowserObject, selector: string, action:
   });
 };
 
-export const getTarget = (driver: BrowserObject, data: { selector: string }) => {
+export const getTarget = (driver: BrowserObject, data: { selector: string }): Promise<ElementWithActions> => {
   const selector = data.selector;
   const getter = selector.indexOf('=>') > -1 ? getTargetFromFrame : getTargetFromMain;
   return getter(driver, selector);

--- a/modules/server/src/main/ts/bedrock/server/KeyEffects.ts
+++ b/modules/server/src/main/ts/bedrock/server/KeyEffects.ts
@@ -2,11 +2,11 @@ import { BrowserObject, Element } from 'webdriverio';
 import * as EffectUtils from './EffectUtils';
 
 interface KeyCombo {
-  key: string;
-  altKey?: boolean;
-  ctrlKey?: boolean;
-  metaKey?: boolean;
-  shiftKey: boolean;
+  readonly key: string;
+  readonly altKey?: boolean;
+  readonly ctrlKey?: boolean;
+  readonly metaKey?: boolean;
+  readonly shiftKey: boolean;
 }
 
 type KeyTextItem = { text: string };
@@ -120,7 +120,7 @@ const performAction = (driver: BrowserObject, target: Element, actions: string[]
   }
 };
 
-const execute = (driver: BrowserObject, data: KeyData) => {
+const execute = (driver: BrowserObject, data: KeyData): Promise<void> => {
   const actions = scan(data.keys);
   return EffectUtils.performActionOnTarget(driver, data, (target) => {
     return performAction(driver, target, actions, driver.isW3C);
@@ -128,7 +128,7 @@ const execute = (driver: BrowserObject, data: KeyData) => {
 };
 
 export const executor = (driver: BrowserObject) => {
-  return (data: KeyData) => {
+  return (data: KeyData): Promise<void> => {
     return execute(driver, data);
   };
 };

--- a/modules/server/src/main/ts/bedrock/server/MouseEffects.ts
+++ b/modules/server/src/main/ts/bedrock/server/MouseEffects.ts
@@ -8,8 +8,8 @@ import * as EffectUtils from './EffectUtils';
  }
  */
 export interface MouseData {
-  type: 'move' | 'click' | 'down' | 'up';
-  selector: string;
+  readonly type: 'move' | 'click' | 'down' | 'up';
+  readonly selector: string;
 }
 
 const performAction = (target: EffectUtils.ElementWithActions, type: string) => {
@@ -18,9 +18,9 @@ const performAction = (target: EffectUtils.ElementWithActions, type: string) => 
     id: 'pointer1',
     parameters: { pointerType: 'mouse' },
     actions: [
-      { type: type, button: 0 },
+      { type, button: 0 },
       { type: 'pause', duration: 10 },
-      { type: type, button: 0 }
+      { type, button: 0 }
     ]
   };
   return target.performActions([action]).then(() => {
@@ -43,14 +43,14 @@ const doAction = (target: EffectUtils.ElementWithActions, type: MouseData['type'
   }
 };
 
-const execute = (driver: BrowserObject, data: MouseData) => {
+const execute = (driver: BrowserObject, data: MouseData): Promise<void> => {
   return EffectUtils.performActionOnTarget(driver, data, (target) => {
     return doAction(target, data.type);
   });
 };
 
 export const executor = (driver: BrowserObject) => {
-  return (data: MouseData) => {
+  return (data: MouseData): Promise<void> => {
     return execute(driver, data);
   };
 };

--- a/modules/server/src/main/ts/bedrock/server/PageRoutes.ts
+++ b/modules/server/src/main/ts/bedrock/server/PageRoutes.ts
@@ -1,6 +1,6 @@
 import * as Routes from './Routes';
 
-export const generate = (projectdir: string, basedir: string) => {
+export const generate = (projectdir: string, basedir: string): Routes.Runner => {
   const routers = [
     Routes.hostOn('GET', '/page', basedir)
   ];
@@ -8,8 +8,8 @@ export const generate = (projectdir: string, basedir: string) => {
   const fallback = Routes.host('GET', projectdir);
 
   return {
-    routers: routers,
-    fallback: fallback
+    routers,
+    fallback
   };
 };
 

--- a/modules/server/src/main/ts/bedrock/server/Routes.ts
+++ b/modules/server/src/main/ts/bedrock/server/Routes.ts
@@ -1,14 +1,19 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import * as server from 'serve-static';
-import * as RouteUtils from '../util/RouteUtils'
+import * as RouteUtils from '../util/RouteUtils';
 import * as Matchers from './Matchers';
 
 type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'OPTIONS';
 
 export type RouteGoFunc = (request: IncomingMessage, response: ServerResponse, done: () => void) => void;
 export interface Route {
-  matches: Matchers.Matcher[];
-  go: RouteGoFunc;
+  readonly matches: Matchers.Matcher[];
+  readonly go: RouteGoFunc;
+}
+
+export interface Runner {
+  readonly routers: Route[];
+  readonly fallback: Route;
 }
 
 const createServer = (root: string) => {
@@ -167,7 +172,7 @@ export const unsupported = (method: HTTPMethod, root: string, label: string): Ro
   };
 };
 
-export const route = (routes: Route[], fallback: Route, request: IncomingMessage, response: ServerResponse, done: (err?: any) => void) => {
+export const route = (routes: Route[], fallback: Route, request: IncomingMessage, response: ServerResponse, done: (err?: any) => void): void => {
   (request as any).originalUrl = request.url;
 
   const match = routes.find((candidate) => {

--- a/modules/server/src/main/ts/bedrock/server/Serve.ts
+++ b/modules/server/src/main/ts/bedrock/server/Serve.ts
@@ -10,32 +10,32 @@ import { DriverMaster } from './DriverMaster';
 import { TestResults } from './Controller';
 
 interface Server {
-  listen: (port: number) => http.Server;
-  close: (callback?: () => void) => void;
+  readonly listen: (port: number) => http.Server;
+  readonly close: (callback?: () => void) => void;
 }
 
 export interface ServeSettings {
-  basedir: string;
-  customRoutes: string;
-  driver: Attempt<string, BrowserObject>;
-  loglevel: 'simple' | 'advanced';
-  master: DriverMaster | null;
-  overallTimeout: number;
-  projectdir: string;
-  runner: any;
-  singleTimeout: number;
-  skipResetMousePosition: boolean;
-  stickyFirstSession: boolean;
-  testfiles: string[];
+  readonly basedir: string;
+  readonly customRoutes: string;
+  readonly driver: Attempt<string, BrowserObject>;
+  readonly loglevel: 'simple' | 'advanced';
+  readonly master: DriverMaster | null;
+  readonly overallTimeout: number;
+  readonly projectdir: string;
+  readonly runner: Routes.Runner;
+  readonly singleTimeout: number;
+  readonly skipResetMousePosition: boolean;
+  readonly stickyFirstSession: boolean;
+  readonly testfiles: string[];
 }
 
 export interface ServeService {
-  port: number;
-  server: Server;
-  markLoaded: () => void;
-  enableHud: () => void;
-  awaitDone: () => Promise<TestResults>;
-  shutdown: () => Promise<void>;
+  readonly port: number;
+  readonly server: Server;
+  readonly markLoaded: () => void;
+  readonly enableHud: () => void;
+  readonly awaitDone: () => Promise<TestResults>;
+  readonly shutdown: () => Promise<void>;
 }
 
 /*
@@ -50,7 +50,7 @@ export interface ServeService {
  */
 export const startCustom = (settings: ServeSettings, createServer: (listener: http.RequestListener) => Server): Promise<ServeService> => {
 
-  const pref = (f: keyof ServeSettings): any => {
+  const pref = <K extends keyof ServeSettings>(f: K): ServeSettings[K] => {
     const v = settings[f];
     if (v === undefined) {
       throw new Error('Object: does not have field: ' + f);
@@ -92,8 +92,8 @@ export const startCustom = (settings: ServeSettings, createServer: (listener: ht
     }).listen(port);
 
     return {
-      port: port,
-      server: server,
+      port,
+      server,
       markLoaded: api.markLoaded,
       enableHud: api.enableHud,
       awaitDone: api.awaitDone,
@@ -109,6 +109,6 @@ export const startCustom = (settings: ServeSettings, createServer: (listener: ht
   });
 };
 
-export const start = (settings: ServeSettings) => {
+export const start = (settings: ServeSettings): Promise<ServeService> => {
   return startCustom(settings, http.createServer);
 };

--- a/modules/server/src/main/ts/bedrock/util/Cmp.ts
+++ b/modules/server/src/main/ts/bedrock/util/Cmp.ts
@@ -17,7 +17,7 @@ export const deepEq = (obj1: any, obj2: any): boolean => {
   });
 };
 
-export const hasAllOf = (obj1: Record<string, any>, obj2: Record<string, any>) => {
+export const hasAllOf = (obj1: Record<string, any>, obj2: Record<string, any>): boolean => {
   return Object.keys(obj2).every((key) => {
     return obj1[key] === obj2[key];
   });

--- a/modules/server/src/main/ts/bedrock/util/Obj.ts
+++ b/modules/server/src/main/ts/bedrock/util/Obj.ts
@@ -1,4 +1,4 @@
-export const toLowerCaseKeys = (items: Record<string, any>) => {
+export const toLowerCaseKeys = (items: Record<string, any>): Record<string, any> => {
   const clone: Record<string, any> = {};
 
   Object.keys(items).forEach((key) => {

--- a/modules/server/src/main/ts/bedrock/util/Qstring.ts
+++ b/modules/server/src/main/ts/bedrock/util/Qstring.ts
@@ -1,6 +1,6 @@
 // NOTE: Replace this with a sensible npm module if you can find one.
 
-export const parse = (url: string) => {
+export const parse = (url: string): { base: string; original: string } => {
   const questionIndex = url.indexOf('?');
   return questionIndex === -1 ? {
     base: url,

--- a/modules/server/src/main/ts/bedrock/util/RouteUtils.ts
+++ b/modules/server/src/main/ts/bedrock/util/RouteUtils.ts
@@ -2,8 +2,11 @@ import * as etag from 'etag';
 import * as fresh from 'fresh';
 import { IncomingMessage, ServerResponse } from 'http';
 
-export const generateETag = (data: any, weak = true) => etag(data, { weak });
+export const generateETag = (data: any, weak = true): string =>
+  etag(data, { weak });
 
-export const isFresh = (request: IncomingMessage, response: ServerResponse) => fresh(request.headers, { etag: response.getHeader('ETag') });
+export const isFresh = (request: IncomingMessage, response: ServerResponse): boolean =>
+  fresh(request.headers, { etag: response.getHeader('ETag') });
 
-export const isCachable = (status: number) => status >= 200 && status < 300;
+export const isCachable = (status: number): boolean =>
+  status >= 200 && status < 300;

--- a/modules/server/src/main/ts/bedrock/util/Shutdown.ts
+++ b/modules/server/src/main/ts/bedrock/util/Shutdown.ts
@@ -1,4 +1,4 @@
-export const registerShutdown = (cb: (code: number, immediate: boolean) => void) => {
+export const registerShutdown = (cb: (code: number, immediate: boolean) => void): void => {
   const killEvents = ['exit', 'SIGTERM', 'SIGINT'];
 
   function register (evName: string) {

--- a/modules/server/src/main/ts/bedrock/util/Type.ts
+++ b/modules/server/src/main/ts/bedrock/util/Type.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
 const typeOf = (x: any): string =>  {
   if (x === null) {
     return 'null';
@@ -17,7 +19,7 @@ const isType = <T>(type: string) => (value: any): value is T => {
 };
 
 export const isString = isType<string>('string');
-export const isObject = isType<object>('object');
+export const isObject = isType<Object>('object');
 export const isArray = isType<Array<any>>('array');
 export const isNull = isType<null>('null');
 export const isBoolean = isType<boolean>('boolean');

--- a/modules/server/src/test/ts/AttemptTest.ts
+++ b/modules/server/src/test/ts/AttemptTest.ts
@@ -85,7 +85,7 @@ describe('attempt.list', () => {
   });
 });
 
-describe("Attempt.hasPassed", () => {
+describe('Attempt.hasPassed', () => {
   it('is true when passed', () => {
     fc.assert(fc.property(arbAttemptPassed(fc.nat()), Attempt.hasPassed));
   });
@@ -94,8 +94,8 @@ describe("Attempt.hasPassed", () => {
   });
 });
 
-describe("Attempt.concat", () => {
-  it("passes if all true", () => {
+describe('Attempt.concat', () => {
+  it('passes if all true', () => {
     fc.assert(fc.property(fc.array(arbAttemptPassed<string[], number>(fc.nat())), (attempts) =>
       Attempt.hasPassed(Attempt.concat(attempts))));
   });

--- a/modules/server/src/test/ts/AttemptUtils.ts
+++ b/modules/server/src/test/ts/AttemptUtils.ts
@@ -11,7 +11,7 @@ export const arbAttemptPassed = <E, A> (arba: Arbitrary<A>): Arbitrary<Attempt<E
 export const arbAttempt = <E, A> (arbe: Arbitrary<E>, arba: Arbitrary<A>): Arbitrary<Attempt<E, A>> =>
   fc.oneof(arbAttemptFailed<E, A>(arbe), arbAttemptPassed<E, A>(arba));
 
-export const assertErrors = <E> (expected: E, actual: Attempt<E, any>) => {
+export const assertErrors = <E> (expected: E, actual: Attempt<E, any>): void => {
   Attempt.cata(actual, (errs) => {
     assert.deepEqual(errs, expected);
   }, () => {
@@ -19,7 +19,7 @@ export const assertErrors = <E> (expected: E, actual: Attempt<E, any>) => {
   });
 };
 
-export const assertResult = <A>(expected: A, actual: Attempt<any, A>) => {
+export const assertResult = <A>(expected: A, actual: Attempt<any, A>): void => {
   Attempt.cata(actual, (errs) => {
     assert.fail('Unexpected errors: ' + JSON.stringify(errs));
   }, result => {

--- a/modules/server/src/test/ts/ClisTest.ts
+++ b/modules/server/src/test/ts/ClisTest.ts
@@ -29,9 +29,9 @@ const cleanResult = <T>(result: Attempt<CliError, T>) =>
 describe('cli', () => {
   it('Minimal specification of bedrock-auto', () => {
     const args = [
-      "--browser", "MicrosoftEdge",
-      "--files", "src/test/resources/test.file1",
-      "--config", "src/test/resources/tsconfig.sample.json"
+      '--browser', 'MicrosoftEdge',
+      '--files', 'src/test/resources/test.file1',
+      '--config', 'src/test/resources/tsconfig.sample.json'
     ];
     const actual = Clis.forAuto(directories, args);
     AttemptUtils.assertResult({
@@ -61,8 +61,8 @@ describe('cli', () => {
 
   it('Specification of bedrock-auto missing required field: browser', () => {
     const args = [
-      "--files", "src/test/resources/test.file1",
-      "--config", "src/test/resources/tsconfig.sample.json"
+      '--files', 'src/test/resources/test.file1',
+      '--config', 'src/test/resources/tsconfig.sample.json'
     ];
     const actual = Clis.forAuto(directories, args);
     AttemptUtils.assertErrors([
@@ -72,8 +72,8 @@ describe('cli', () => {
 
   it('Minimal specification of bedrock-manual', () => {
     const args = [
-      "--files", "src/test/resources/test.file1",
-      "--config", "src/test/resources/tsconfig.sample.json"
+      '--files', 'src/test/resources/test.file1',
+      '--config', 'src/test/resources/tsconfig.sample.json'
     ];
     const actual = Clis.forManual(directories, args);
     AttemptUtils.assertResult( {

--- a/modules/server/src/test/ts/TypeTest.ts
+++ b/modules/server/src/test/ts/TypeTest.ts
@@ -4,11 +4,11 @@ import { describe, it } from 'mocha';
 import * as Type from '../../main/ts/bedrock/util/Type';
 
 describe('Type.isString', () => {
-  it("is true for strings", () => {
+  it('is true for strings', () => {
     fc.assert(fc.property(fc.string(), Type.isString));
   });
 
-  it("is false for undefined", () => {
+  it('is false for undefined', () => {
     assert.isFalse(Type.isString(undefined));
-  })
+  });
 });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test-server": "yarn workspace @ephox/bedrock-server test",
     "test-sample": "yarn workspace @ephox/bedrock-sample test",
     "test-samples-fail": "yarn workspace @ephox/bedrock-sample test-samples-fail",
-    "test": "yarn build && yarn lerna run test"
+    "test": "yarn build && yarn lint && yarn lerna run test"
   },
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Over the weekend, I found we had a number of linter issues which weren't picked up as the linter didn't run in CI, etc... So this fixes those issues, adds a couple other common rules and makes the linter run when running `yarn test`.