### PR TITLE
TINY-6732: Updated bedrock to support pulling in specified polyfills

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Version 10.0.0
 * Added support for retries and timeouts per test for mocha compatibility.
 * Added support for skipping tests.
 * Added support for "only" tests.
+* Added the `--polyfills` command line parameter which allows including core-js polyfills as part of the test run.
 
 Version 9.7.1
 

--- a/modules/sample/package.json
+++ b/modules/sample/package.json
@@ -7,7 +7,7 @@
     "test-samples-pass": "../server/bin/bedrock-auto.js -b phantomjs --config tsconfig.json --polyfills Promise Symbol --files src/test/ts/**/*PassTest.ts src/test/ts/**/*PassTest.tsx",
     "test-samples-only": "../server/bin/bedrock-auto.js -b phantomjs --config tsconfig.json --polyfills Promise Symbol --files src/test/ts/**/*OnlyTest.ts",
     "test-samples-pass-js": "../server/bin/bedrock-auto.js -b phantomjs --polyfills Promise Symbol --files src/test/js/**/*PassTest.js",
-    "test-samples-pass-manual": "../server/bin/bedrock.js --config tsconfig.json --polyfills Promise Symbol --files src/test/ts/**/*PassTest.ts",
+    "test-samples-pass-manual": "../server/bin/bedrock.js --config tsconfig.json --polyfills Promise Symbol --files src/test/ts/**/*PassTest.ts src/test/ts/**/*PassTest.tsx",
     "test-samples-pass-manual-js": "../server/bin/bedrock.js --polyfills Promise Symbol --files src/test/js/**/*PassTest.js",
     "test-samples-fail": "../server/bin/bedrock-auto.js -b phantomjs --config tsconfig.json --files src/test/ts/**/*FailTest.ts",
     "test": "yarn test-samples-pass && yarn test-samples-only && yarn test-samples-pass-js"

--- a/modules/sample/package.json
+++ b/modules/sample/package.json
@@ -4,11 +4,11 @@
   "author": "Tiny Technologies Inc",
   "license": "Apache-2.0",
   "scripts": {
-    "test-samples-pass": "../server/bin/bedrock-auto.js -b phantomjs --config tsconfig.json --files src/test/ts/**/*PassTest.ts src/test/ts/**/*PassTest.tsx",
-    "test-samples-only": "../server/bin/bedrock-auto.js -b phantomjs --config tsconfig.json --files src/test/ts/**/*OnlyTest.ts",
-    "test-samples-pass-js": "../server/bin/bedrock-auto.js -b phantomjs --files src/test/js/**/*PassTest.js",
-    "test-samples-pass-manual": "../server/bin/bedrock.js --config tsconfig.json --files src/test/ts/**/*PassTest.ts src/test/ts/**/*PassTest.tsx",
-    "test-samples-pass-manual-js": "../server/bin/bedrock.js --files src/test/js/**/*PassTest.js",
+    "test-samples-pass": "../server/bin/bedrock-auto.js -b phantomjs --config tsconfig.json --polyfills Promise Symbol --files src/test/ts/**/*PassTest.ts src/test/ts/**/*PassTest.tsx",
+    "test-samples-only": "../server/bin/bedrock-auto.js -b phantomjs --config tsconfig.json --polyfills Promise Symbol --files src/test/ts/**/*OnlyTest.ts",
+    "test-samples-pass-js": "../server/bin/bedrock-auto.js -b phantomjs --polyfills Promise Symbol --files src/test/js/**/*PassTest.js",
+    "test-samples-pass-manual": "../server/bin/bedrock.js --config tsconfig.json --polyfills Promise Symbol --files src/test/ts/**/*PassTest.ts",
+    "test-samples-pass-manual-js": "../server/bin/bedrock.js --polyfills Promise Symbol --files src/test/js/**/*PassTest.js",
     "test-samples-fail": "../server/bin/bedrock-auto.js -b phantomjs --config tsconfig.json --files src/test/ts/**/*FailTest.ts",
     "test": "yarn test-samples-pass && yarn test-samples-only && yarn test-samples-pass-js"
   },

--- a/modules/sample/src/test/ts/client/BddPassTest.ts
+++ b/modules/sample/src/test/ts/client/BddPassTest.ts
@@ -32,6 +32,13 @@ describe('BDD Pass', () => {
       setTimeout(done, 100);
     });
 
+    it('should work with async Promise function', async () => {
+      assert.eq(1, count);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+    });
+
     it('should work with retries', () => {
       retryCount++;
       assert.eq(3, retryCount);

--- a/modules/server/src/main/ts/BedrockAuto.ts
+++ b/modules/server/src/main/ts/BedrockAuto.ts
@@ -31,18 +31,11 @@ export const go = (settings: BedrockAutoSettings): void => {
     }).then((driver) => {
       const webdriver = driver.webdriver;
       const serveSettings: Serve.ServeSettings = {
-        projectdir: settings.projectdir,
-        basedir: settings.basedir,
-        testfiles: settings.testfiles,
+        ...settings,
         driver: Attempt.passed(webdriver),
         master,
         runner,
-        loglevel: settings.loglevel,
-        customRoutes: settings.customRoutes,
-        stickyFirstSession: true,
-        overallTimeout: settings.overallTimeout,
-        singleTimeout: settings.singleTimeout,
-        skipResetMousePosition: settings.skipResetMousePosition
+        stickyFirstSession: true
       };
 
       return Serve.start(serveSettings).then((service) => {

--- a/modules/server/src/main/ts/BedrockAuto.ts
+++ b/modules/server/src/main/ts/BedrockAuto.ts
@@ -17,7 +17,7 @@ export const go = (settings: BedrockAutoSettings): void => {
   const isPhantom = settings.browser === 'phantomjs';
 
   const basePage = 'src/resources/html/' + (isPhantom ? 'bedrock-phantom.html' : 'bedrock.html');
-  const routes = RunnerRoutes.generate('auto', settings.projectdir, settings.basedir, settings.config, settings.bundler, settings.testfiles, settings.chunk, settings.retries, settings.singleTimeout, settings.stopOnFailure, basePage, settings.coverage);
+  const routes = RunnerRoutes.generate('auto', settings.projectdir, settings.basedir, settings.config, settings.bundler, settings.testfiles, settings.chunk, settings.retries, settings.singleTimeout, settings.stopOnFailure, basePage, settings.coverage, settings.polyfills);
 
   console.log('bedrock-auto ' + Version.get() + ' starting...');
 

--- a/modules/server/src/main/ts/BedrockCli.ts
+++ b/modules/server/src/main/ts/BedrockCli.ts
@@ -1,9 +1,10 @@
+import { CliError } from './bedrock/cli/Cli';
 import { Attempt } from './bedrock/core/Attempt';
 import * as Clis from './bedrock/cli/Clis';
 import { BedrockSettings } from './bedrock/core/Settings';
 
 type Program = {
-  go: (settings: BedrockSettings, directories: { current: string; bin: string }) => void;
+  go: <T extends BedrockSettings>(settings: T, directories: { current: string; bin: string }) => void;
   mode: 'forAuto' | 'forManual' | 'forFramework';
 }
 
@@ -12,8 +13,8 @@ export const run = (program: Program, directories: { current: string; bin: strin
     throw new Error('Bedrock mode not known: ' + program.mode);
   }
 
-  const maybeSettings = Clis[program.mode](directories);
-  Attempt.cata(maybeSettings, Clis.logAndExit, (settings: BedrockSettings) => {
+  const maybeSettings: Attempt<CliError, BedrockSettings> = Clis[program.mode](directories);
+  Attempt.cata(maybeSettings, Clis.logAndExit, (settings) => {
     program.go(settings, directories);
   });
 };

--- a/modules/server/src/main/ts/BedrockFramework.ts
+++ b/modules/server/src/main/ts/BedrockFramework.ts
@@ -23,17 +23,13 @@ export const go = (settings: BedrockFrameworkSettings): void => {
   }).then((driver) => {
     const webdriver = driver.webdriver;
     const serveSettings: Serve.ServeSettings = {
-      projectdir: settings.projectdir,
-      basedir: settings.basedir,
+      ...settings,
       driver: Attempt.passed(webdriver),
       testfiles: [],
       master,
       runner,
-      loglevel: settings.loglevel,
       customRoutes: undefined,
       stickyFirstSession: true,
-      overallTimeout: settings.overallTimeout,
-      singleTimeout: settings.singleTimeout,
       skipResetMousePosition: false
     };
 

--- a/modules/server/src/main/ts/BedrockFramework.ts
+++ b/modules/server/src/main/ts/BedrockFramework.ts
@@ -30,7 +30,7 @@ export const go = (settings: BedrockFrameworkSettings): void => {
       master,
       runner,
       loglevel: settings.loglevel,
-      customRoutes: settings.customRoutes,
+      customRoutes: undefined,
       stickyFirstSession: true,
       overallTimeout: settings.overallTimeout,
       singleTimeout: settings.singleTimeout,

--- a/modules/server/src/main/ts/BedrockFramework.ts
+++ b/modules/server/src/main/ts/BedrockFramework.ts
@@ -28,8 +28,10 @@ export const go = (settings: BedrockFrameworkSettings): void => {
       testfiles: [],
       master,
       runner,
+      // Framework mode doesn't support the --customRoutes argument, so just pass undefined
       customRoutes: undefined,
       stickyFirstSession: true,
+      // Framework mode doesn't support the --skipResetMousePosition argument, so never skip
       skipResetMousePosition: false
     };
 

--- a/modules/server/src/main/ts/BedrockManual.ts
+++ b/modules/server/src/main/ts/BedrockManual.ts
@@ -13,20 +13,11 @@ export const go = (settings: BedrockManualSettings): void => {
 
   routes.then((runner) => {
     const serveSettings: Webpack.WebpackServeSettings = {
-      projectdir: settings.projectdir,
-      basedir: settings.basedir,
-      testfiles: settings.testfiles,
+      ...settings,
       // There is no driver for manual mode.
       driver: Attempt.failed('There is no webdriver for manual mode'),
       master: null, // there is no need for master,
       runner,
-      loglevel: settings.loglevel,
-      customRoutes: settings.customRoutes,
-      config: settings.config,
-      coverage: settings.coverage,
-      overallTimeout: settings.overallTimeout,
-      singleTimeout: settings.singleTimeout,
-      polyfills: settings.polyfills,
       // sticky session is used by auto mode only
       stickyFirstSession: false,
       // reset mouse position will never work on manual

--- a/modules/server/src/main/ts/BedrockManual.ts
+++ b/modules/server/src/main/ts/BedrockManual.ts
@@ -2,12 +2,12 @@ import { Attempt } from './bedrock/core/Attempt';
 import * as Version from './bedrock/core/Version';
 import * as RunnerRoutes from './bedrock/server/RunnerRoutes';
 import * as Webpack from './bedrock/compiler/Webpack';
-import { BedrockSettings } from './bedrock/core/Settings';
+import { BedrockManualSettings } from './bedrock/core/Settings';
 import { ExitCodes } from './bedrock/util/ExitCodes';
 
-export const go = (settings: BedrockSettings): void => {
+export const go = (settings: BedrockManualSettings): void => {
   const basePage = 'src/resources/html/bedrock.html';
-  const routes = RunnerRoutes.generate('manual', settings.projectdir, settings.basedir, settings.config, settings.bundler, settings.testfiles, settings.chunk, 0, settings.singleTimeout, true, basePage, settings.coverage);
+  const routes = RunnerRoutes.generate('manual', settings.projectdir, settings.basedir, settings.config, settings.bundler, settings.testfiles, settings.chunk, 0, settings.singleTimeout, true, basePage, settings.coverage, settings.polyfills);
 
   console.log('bedrock-manual ' + Version.get() + ' starting...');
 
@@ -26,6 +26,7 @@ export const go = (settings: BedrockSettings): void => {
       coverage: settings.coverage,
       overallTimeout: settings.overallTimeout,
       singleTimeout: settings.singleTimeout,
+      polyfills: settings.polyfills,
       // sticky session is used by auto mode only
       stickyFirstSession: false,
       // reset mouse position will never work on manual

--- a/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
+++ b/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
@@ -311,3 +311,13 @@ export const skipResetMousePosition: ClOption = {
   validate: Extraction.any,
   uncommon: true
 };
+
+export const polyfills: ClOption = {
+  name: 'polyfills',
+  type: String,
+  multiple: true,
+  defaultValue: [ 'Symbol' ],
+  description: 'CoreJS polyfills to apply when running tests',
+  validate: Extraction.inSet([ 'ArrayBuffer', 'Map', 'Object', 'Promise', 'Set', 'Symbol', 'TypedArray', 'WeakMap', 'WeakSet' ]),
+  uncommon: true
+};

--- a/modules/server/src/main/ts/bedrock/cli/Clis.ts
+++ b/modules/server/src/main/ts/bedrock/cli/Clis.ts
@@ -2,7 +2,7 @@ import * as cli from './Cli';
 import * as ClOptions from './ClOptions';
 import { ExitCodes } from '../util/ExitCodes';
 import { Attempt } from '../core/Attempt';
-import { BedrockAutoSettings, BedrockFrameworkSettings, BedrockSettings } from '../core/Settings';
+import { BedrockAutoSettings, BedrockFrameworkSettings, BedrockManualSettings } from '../core/Settings';
 
 export interface Directories {
   current: string;
@@ -40,11 +40,12 @@ export const forAuto = (directories: Directories, argv: string[] = process.argv)
     ClOptions.useSandboxForHeadless,
     ClOptions.skipResetMousePosition,
     ClOptions.coverage,
-    ClOptions.wipeBrowserCache
+    ClOptions.wipeBrowserCache,
+    ClOptions.polyfills
   ]), argv) as Attempt<cli.CliError, BedrockAutoSettings>;
 };
 
-export const forManual = (directories: Directories, argv: string[] = process.argv): Attempt<cli.CliError, BedrockSettings> => {
+export const forManual = (directories: Directories, argv: string[] = process.argv): Attempt<cli.CliError, BedrockManualSettings> => {
   return cli.extract('bedrock', 'Launch a testing process on a localhost port and allow the user to navigate to it in any browser', commonOptions(directories).concat([
     ClOptions.stopOnFailure__hidden,
     ClOptions.config,
@@ -52,8 +53,9 @@ export const forManual = (directories: Directories, argv: string[] = process.arg
     ClOptions.testdir,
     ClOptions.testdirs,
     ClOptions.customRoutes,
-    ClOptions.coverage
-  ]), argv) as Attempt<cli.CliError, BedrockSettings>;
+    ClOptions.coverage,
+    ClOptions.polyfills
+  ]), argv) as Attempt<cli.CliError, BedrockManualSettings>;
 };
 
 export const forFramework = (directories: Directories, argv: string[] = process.argv): Attempt<cli.CliError, BedrockFrameworkSettings> => {

--- a/modules/server/src/main/ts/bedrock/compiler/Compiler.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Compiler.ts
@@ -5,7 +5,7 @@ export interface Compiler {
   readonly generate: () => Promise<Buffer | string>;
 }
 
-export const compile = (tsConfigFile: string, scratchDir: string, basedir: string, exitOnCompileError: boolean, files: string[], coverage: string[]): Compiler => {
+export const compile = (tsConfigFile: string, scratchDir: string, basedir: string, exitOnCompileError: boolean, files: string[], coverage: string[], polyfills: string[]): Compiler => {
   const getCompileFunc = () => {
     return Webpack.compile;
   };
@@ -18,7 +18,8 @@ export const compile = (tsConfigFile: string, scratchDir: string, basedir: strin
       basedir,
       exitOnCompileError,
       files,
-      coverage
+      coverage,
+      polyfills
     ).then((compiledJsFilePath) => fs.readFileSync(compiledJsFilePath));
   };
 

--- a/modules/server/src/main/ts/bedrock/compiler/Imports.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Imports.ts
@@ -1,6 +1,12 @@
 import * as path from 'path';
 import { hasTs } from './TsUtils';
 
+const convertPolyfillNameToPath = (name: string) => {
+  const path = name.slice(0, 1).toLowerCase() +
+               name.slice(1).replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+  return `core-js/es/${path}`;
+};
+
 const filePathToImport = (useRequire: boolean, scratchFile: string) => {
   return (filePath: string) => {
     const importFilePath = path.join(path.dirname(filePath), path.basename(filePath, path.extname(filePath)));
@@ -22,18 +28,25 @@ addTest("${filePath}");`;
   };
 };
 
-const generatePolyfills = (useRequire: boolean): string => {
-  // For IE support we need to load some polyfills
-  const symbolPolyfill = `if (window['Symbol'] === undefined) {
-  ${useRequire ? 'window.Symbol = require(\'core-js/es/symbol\');' : 'import \'core-js/es/symbol\';'}
-}`;
-  return [ symbolPolyfill ].join('\n');
+const generatePolyfillImport = (useRequire: boolean, importPath: string) => {
+  return useRequire ? `require('${importPath}');` : `import '${importPath}';`;
 };
 
-const generateImportsTs = (useRequire: boolean, scratchFile: string, srcFiles: string[]) => {
+const generatePolyfills = (useRequire: boolean, polyfills: Record<string, string>): string => {
+  const polyfillImports: string[] = [];
+  Object.keys(polyfills).forEach((name) => {
+    const path = polyfills[name];
+    polyfillImports.push(`if (window['${name}'] === undefined) {
+  ${generatePolyfillImport(useRequire, path)}
+}`);
+  });
+  return polyfillImports.join('\n');
+};
+
+const generateImportsTs = (useRequire: boolean, scratchFile: string, srcFiles: string[], polyfills: Record<string, string>) => {
   const imports = srcFiles.map(filePathToImport(useRequire, scratchFile)).join('\n');
   // header code for tests.ts
-  return `${generatePolyfills(useRequire)}
+  return `${generatePolyfills(useRequire, polyfills)}
 
 declare let require: any;
 declare let __tests: any[];
@@ -81,10 +94,10 @@ window.removeEventListener('error', importErrorHandler);
 export {};`;
 };
 
-const generateImportsJs = (useRequire: boolean, scratchFile: string, srcFiles: string[]) => {
+const generateImportsJs = (useRequire: boolean, scratchFile: string, srcFiles: string[], polyfills: Record<string, string>) => {
   const imports = srcFiles.map(filePathToImport(useRequire, scratchFile)).join('\n');
   // header code for tests-imports.js
-  return `${generatePolyfills(useRequire)}
+  return `${generatePolyfills(useRequire, polyfills)}
 
 var __lastTestIndex = -1;
 var __currentTestFile;
@@ -129,10 +142,15 @@ window.removeEventListener('error', importErrorHandler);
 export {};`;
 };
 
-export const generateImports = (useRequire: boolean, scratchFile: string, srcFiles: string[]): string => {
+export const generateImports = (useRequire: boolean, scratchFile: string, srcFiles: string[], polyfills: string[]): string => {
+  const polyfillPaths: Record<string, string> = {};
+  polyfills.forEach((name) => {
+    polyfillPaths[name] = convertPolyfillNameToPath(name);
+  });
+
   if (hasTs(srcFiles)) {
-    return generateImportsTs(useRequire, scratchFile, srcFiles);
+    return generateImportsTs(useRequire, scratchFile, srcFiles, polyfillPaths);
   } else {
-    return generateImportsJs(useRequire, scratchFile, srcFiles);
+    return generateImportsJs(useRequire, scratchFile, srcFiles, polyfillPaths);
   }
 };

--- a/modules/server/src/main/ts/bedrock/compiler/Imports.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Imports.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { hasTs } from './TsUtils';
 
-const convertPolyfillNameToPath = (name: string) => {
+export const convertPolyfillNameToPath = (name: string): string => {
   const path = name.slice(0, 1).toLowerCase() +
                name.slice(1).replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
   return `core-js/es/${path}`;
@@ -148,9 +148,6 @@ export const generateImports = (useRequire: boolean, scratchFile: string, srcFil
     polyfillPaths[name] = convertPolyfillNameToPath(name);
   });
 
-  if (hasTs(srcFiles)) {
-    return generateImportsTs(useRequire, scratchFile, srcFiles, polyfillPaths);
-  } else {
-    return generateImportsJs(useRequire, scratchFile, srcFiles, polyfillPaths);
-  }
+  const f = hasTs(srcFiles) ? generateImportsTs : generateImportsJs;
+  return f(useRequire, scratchFile, srcFiles, polyfillPaths);
 };

--- a/modules/server/src/main/ts/bedrock/core/Settings.ts
+++ b/modules/server/src/main/ts/bedrock/core/Settings.ts
@@ -2,26 +2,35 @@ export interface BedrockSettings {
   readonly basedir: string;
   readonly bundler: 'webpack' | 'rollup';
   readonly chunk: number;
-  readonly config: string;
-  readonly coverage: string[];
-  readonly customRoutes: string;
   readonly gruntDone?: (success: boolean) => void;
   readonly loglevel: 'simple' | 'advanced';
-  readonly name: string;
-  readonly output: string;
   readonly overallTimeout: number;
   readonly projectdir: string;
   readonly singleTimeout: number;
+  readonly stopOnFailure: boolean;
+}
+
+export interface BedrockManualSettings extends BedrockSettings {
+  readonly config: string;
+  readonly coverage: string[];
+  readonly customRoutes: string;
+  readonly polyfills: string[];
   readonly testfiles: string[];
 }
 
 export interface BedrockAutoSettings extends BedrockSettings {
   readonly browser: string;
+  readonly config: string;
+  readonly coverage: string[];
+  readonly customRoutes: string;
   readonly debuggingPort: number;
   readonly delayExit: boolean;
+  readonly name: string;
+  readonly output: string;
+  readonly polyfills: string[];
   readonly retries: number;
   readonly skipResetMousePosition: boolean;
-  readonly stopOnFailure: boolean;
+  readonly testfiles: string[];
   readonly useSandboxForHeadless: boolean;
   readonly wipeBrowserCache: boolean;
 }
@@ -30,6 +39,7 @@ export interface BedrockFrameworkSettings extends BedrockSettings {
   readonly browser: string;
   readonly debuggingPort: number;
   readonly framework: string;
+  readonly name: string;
+  readonly output: string;
   readonly page: string;
-  readonly stopOnFailure: boolean;
 }

--- a/modules/server/src/main/ts/bedrock/server/CustomRoutes.ts
+++ b/modules/server/src/main/ts/bedrock/server/CustomRoutes.ts
@@ -109,7 +109,7 @@ const jsonToRouters = (data: CustomRouteSpec[], configPath: string) => {
   });
 };
 
-const fallbackGo = (filePath: string): Routes.RouteGoFunc => {
+const fallbackGo = (filePath: string | undefined): Routes.RouteGoFunc => {
   return (request, response, done) => {
     response.writeHead(404, {'content-type': 'text/plain'});
     response.end([
@@ -123,7 +123,7 @@ const fallbackGo = (filePath: string): Routes.RouteGoFunc => {
   };
 };
 
-const go = (filePath: string): Routes.RouteGoFunc => {
+const go = (filePath: string | undefined): Routes.RouteGoFunc => {
   const fallback: Routes.Route = { matches: [], go: fallbackGo(filePath) };
   return (request, response, done) => {
     const routers = filePath ? jsonToRouters(FileUtils.readFileAsJson(filePath), filePath) : [];
@@ -134,7 +134,7 @@ const go = (filePath: string): Routes.RouteGoFunc => {
   };
 };
 
-const routers = (filePath: string) => {
+const routers = (filePath: string | undefined) => {
   return [
     {
       matches: [Matchers.prefixMatch('/custom')],
@@ -143,7 +143,7 @@ const routers = (filePath: string) => {
   ];
 };
 
-export const create = (filePath: string): { routers: Routes.Route[] } => {
+export const create = (filePath: string | undefined): { routers: Routes.Route[] } => {
   return {
     routers: routers(filePath)
   };

--- a/modules/server/src/main/ts/bedrock/server/RunnerRoutes.ts
+++ b/modules/server/src/main/ts/bedrock/server/RunnerRoutes.ts
@@ -11,7 +11,8 @@ interface PackageJson {
   readonly workspaces: string[];
 }
 
-export const generate = (mode: string, projectdir: string, basedir: string, configFile: string, bundler: 'webpack' | 'rollup', testfiles: string[], chunk: number, retries: number, singleTimeout: number, stopOnFailure: boolean, basePage: string, coverage: string[]): Promise<Routes.Runner> => {
+export const generate = (mode: string, projectdir: string, basedir: string, configFile: string, bundler: 'webpack' | 'rollup', testfiles: string[], chunk: number,
+                         retries: number, singleTimeout: number, stopOnFailure: boolean, basePage: string, coverage: string[], polyfills: string[]): Promise<Routes.Runner> => {
   const files = testfiles.map((filePath) => {
     return path.relative(projectdir, filePath);
   });
@@ -22,7 +23,8 @@ export const generate = (mode: string, projectdir: string, basedir: string, conf
     basedir,
     mode === 'auto',
     files,
-    coverage
+    coverage,
+    polyfills
   );
 
   // read the project json file to determine the project name to expose resources as `/project/${name}`

--- a/modules/server/src/main/ts/bedrock/server/Serve.ts
+++ b/modules/server/src/main/ts/bedrock/server/Serve.ts
@@ -16,7 +16,7 @@ interface Server {
 
 export interface ServeSettings {
   readonly basedir: string;
-  readonly customRoutes: string;
+  readonly customRoutes: string | undefined;
   readonly driver: Attempt<string, BrowserObject>;
   readonly loglevel: 'simple' | 'advanced';
   readonly master: DriverMaster | null;

--- a/modules/server/src/test/ts/ClisTest.ts
+++ b/modules/server/src/test/ts/ClisTest.ts
@@ -53,6 +53,7 @@ describe('cli', () => {
       version: false,
       chunk: 100,
       retries: 0,
+      polyfills: [ 'Symbol' ],
       useSandboxForHeadless: false,
       skipResetMousePosition: false,
       wipeBrowserCache: false
@@ -88,7 +89,8 @@ describe('cli', () => {
       overallTimeout: 600000,
       loglevel: 'advanced',
       version: false,
-      chunk: 100
+      chunk: 100,
+      polyfills: [ 'Symbol' ]
     }, Attempt.map(actual, exclude(['projectdir', 'basedir'])));
   });
 });

--- a/modules/server/src/test/ts/compiler/ImportsTest.ts
+++ b/modules/server/src/test/ts/compiler/ImportsTest.ts
@@ -1,0 +1,99 @@
+import { assert } from 'chai';
+import * as fc from 'fast-check';
+import { describe, it } from 'mocha';
+import { generateImports } from '../../../main/ts/bedrock/compiler/Imports';
+
+const validPolyfills = [ 'ArrayBuffer', 'Map', 'Object', 'Promise', 'Set', 'Symbol', 'TypedArray', 'WeakMap', 'WeakSet' ];
+
+const convertPolyfillName = (name: string) => {
+  return name.slice(0, 1).toLowerCase() +
+    name.slice(1).replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+};
+
+const withGenerateFilenames = (useRequire: boolean, extension: string, test: (imports: string, filenames: string[]) => void) => {
+  fc.assert(fc.property(fc.array(fc.hexaString(1, 20), 50), (filenames) => {
+    const filepaths = filenames.map((name) => `/${name}.${extension}`);
+    const imports = generateImports(useRequire, `/scratch.${extension}`, filepaths, []);
+    test(imports, filenames);
+  }));
+};
+
+describe('Imports.generateImports', () => {
+  context('TypeScript', () => {
+    it('should include the specified test files (require)', () => {
+      withGenerateFilenames(true, 'ts', (imports, filenames) => {
+        filenames.forEach((filename) => {
+          assert.include(imports, `
+__currentTestFile = "/${filename}.ts";
+require("${filename}");
+addTest("/${filename}.ts");`
+          );
+        });
+      });
+    });
+
+    it('should include the specified test files (import)', () => {
+      withGenerateFilenames(false, 'ts', (imports, filenames) => {
+        filenames.forEach((filename) => {
+          assert.include(imports, `
+__currentTestFile = "/${filename}.ts";
+import "${filename}";
+addTest("/${filename}.ts");`
+          );
+        });
+      });
+    });
+  });
+
+  context('JavaScript', () => {
+    it('should include the specified test files (require)', () => {
+      withGenerateFilenames(true, 'js', (imports, filenames) => {
+        filenames.forEach((filename) => {
+          assert.include(imports, `
+__currentTestFile = "/${filename}.js";
+require("${filename}");
+addTest("/${filename}.js");`
+          );
+        });
+      });
+    });
+
+    it('should include the specified test files (import)', () => {
+      withGenerateFilenames(false, 'js', (imports, filenames) => {
+        filenames.forEach((filename) => {
+          assert.include(imports, `
+__currentTestFile = "/${filename}.js";
+import "${filename}";
+addTest("/${filename}.js");`
+          );
+        });
+      });
+    });
+  });
+
+  it('should include an error catcher for imports', () => {
+    const imports = generateImports(true, '/scratch.ts', [], []);
+    assert.include(imports, 'window.addEventListener(\'error\', importErrorHandler);');
+    assert.include(imports, 'window.removeEventListener(\'error\', importErrorHandler);');
+  });
+
+  it('should include the specified polyfills (require)', () => {
+    fc.assert(fc.property(fc.array(fc.constantFrom(...validPolyfills)), (polyfills) => {
+      const imports = generateImports(true, '/scratch.ts', [], polyfills);
+
+      polyfills.forEach((polyfill) => {
+        assert.include(imports, `require('core-js/es/${convertPolyfillName(polyfill)}');`);
+      });
+    }));
+  });
+
+  it('should include the specified polyfills (import)', () => {
+    fc.assert(fc.property(fc.array(fc.constantFrom(...validPolyfills)), (polyfills) => {
+      const imports = generateImports(false, '/scratch.ts', [], polyfills);
+
+      polyfills.forEach((polyfill) => {
+        assert.include(imports, `import 'core-js/es/${convertPolyfillName(polyfill)}';`);
+      });
+    }));
+  });
+});


### PR DESCRIPTION
This adds the ability to include additional polyfills as part of the test run by adding for example `--polyfills Promise Symbol`. The default is `Symbol` to keep backwards compatibility and I didn't add `Promise` as part of that as discussed with the Editor Team on slack.

This will allow us to write `async`/`await` tests in TinyMCE and rely on the Promise eslint rule to ensure we don't misuse a Promise for IE 11.