### PR TITLE
TINY-6732: Fixed tests failing if the title contained "??" in the title

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @spocke @jhaines @metricjs @lnewson @ltrouton @tinydylan
+* @spocke @metricjs @lnewson @ltrouton @techtangents @ashfordneil @JamesToohey

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 10.0.1
+
+* Fixed tests failing if the title contained "??" in the title.
+
 Version 10.0.0
 
 * Added new `Bdd` module for using mocha compatible BDD style tests.

--- a/modules/runner/src/main/ts/reporter/Callbacks.ts
+++ b/modules/runner/src/main/ts/reporter/Callbacks.ts
@@ -17,9 +17,12 @@ const sendJson = <T>(url: string, data: any): Promise<T> => {
     $.ajax({
       method: 'post',
       url,
+      contentType: 'application/json; charset=UTF-8',
       dataType: 'json',
       success: onSuccess,
-      error: onError,
+      error: (xhr, statusText, e) => {
+        onError(e);
+      },
       data: JSON.stringify(data),
     });
   });
@@ -31,7 +34,9 @@ const getJson = <T>(url: string): Promise<T> => {
       url,
       dataType: 'json',
       success: onSuccess,
-      error: onError,
+      error: (xhr, statusText, e) => {
+        onError(e);
+      }
     });
   }));
 };

--- a/modules/sample/src/test/ts/client/BddPassTest.ts
+++ b/modules/sample/src/test/ts/client/BddPassTest.ts
@@ -44,6 +44,10 @@ describe('BDD Pass', () => {
       assert.eq(3, retryCount);
     }).retries(2);
 
+    it('should work with tests that contain ?? in the title', () => {
+      assert.eq(true, true);
+    });
+
     it.skip('should be skipped with outer call', () => {
       throw new Error('This should never run');
     });


### PR DESCRIPTION
If a test title contains ?? then the test fails with the error message [object Object]. This is because we're not setting the content type, so it's treating the string as "application/x-www-form-urlencoded" and that tries jQueries magic ?? replacement logic. See: https://api.jquery.com/jquery.ajax/

Note: I've also updated the CODEOWNERS to better reflect the current reviewers for bedrock