### PR TITLE
TINY-6882: Fixed beforeEach and afterEach hooks running in the wrong order

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 10.0.2
+
+* Fixed beforeEach and afterEach hooks running in the wrong order.
+
 Version 10.0.1
 
 * Fixed tests failing if the title contained "??" in the title.

--- a/modules/runner/src/main/ts/runner/Hooks.ts
+++ b/modules/runner/src/main/ts/runner/Hooks.ts
@@ -13,8 +13,13 @@ export const getHooks = (suite: Suite, type: HookType, includeParents: boolean):
   } else {
     const hooks = suite.hooks[type];
     if (includeParents && suite.parent !== undefined) {
-      const allHooks = hooks.concat(getHooks(suite.parent, type, includeParents));
-      return type === HookType.AfterEach || type === HookType.After ? allHooks.reverse() : allHooks;
+      const parentHooks = getHooks(suite.parent, type, includeParents);
+      // Reverse the suite hook order for after hooks so it gets the suite hooks bottom up
+      if (type === HookType.After || type === HookType.AfterEach) {
+        return hooks.concat(parentHooks);
+      } else {
+        return parentHooks.concat(hooks);
+      }
     } else {
       return hooks;
     }

--- a/modules/runner/src/test/ts/runner/HooksTest.ts
+++ b/modules/runner/src/test/ts/runner/HooksTest.ts
@@ -55,15 +55,15 @@ describe('Hooks.runHooks', () => {
     RunnerTestUtils.populateHooks(nested, 2, (idx) => callStack.push('nested' + idx));
   });
 
-  it('runs beforeEach hooks from bottom up', () => {
+  it('runs beforeEach hooks from top down', () => {
     return Hooks.runHooks(nested, HookType.BeforeEach, true).then(() => {
-      assert.deepEqual(callStack, [ 'nested0', 'nested1', 'root0', 'root1' ]);
+      assert.deepEqual(callStack, [ 'root0', 'root1', 'nested0', 'nested1' ]);
     });
   });
 
-  it('runs afterEach hooks from top down', () => {
+  it('runs afterEach hooks from bottom up', () => {
     return Hooks.runHooks(nested, HookType.AfterEach, true).then(() => {
-      assert.deepEqual(callStack, [ 'root1', 'root0', 'nested1', 'nested0' ]);
+      assert.deepEqual(callStack, [ 'nested0', 'nested1', 'root0', 'root1' ]);
     });
   });
 


### PR DESCRIPTION
See the JIRA for more details and a replication case in Mocha to show this is how it should be working.