### PR TITLE
TINY-6897: Fixed bedrock not returning a non-zero error code when tests unexpectedly stopped

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 11.0.1
+
+* Fixed bedrock not returning a non-zero error code when tests unexpectedly stopped.
+
 Version 11.0.0
 
 * Removed "framework" mode, which was used for running QUnit tests.

--- a/modules/runner/src/main/ts/reporter/Callbacks.ts
+++ b/modules/runner/src/main/ts/reporter/Callbacks.ts
@@ -7,7 +7,7 @@ export interface Callbacks {
   readonly sendKeepAlive: (session: string) => Promise<void>;
   readonly sendTestStart: (session: string, totalTests: number, file: string, name: string) => Promise<void>;
   readonly sendTestResult: (session: string, file: string, name: string, passed: boolean, time: string, error: string | null, skipped: string | null) => Promise<void>;
-  readonly sendDone: (session: string) => Promise<void>;
+  readonly sendDone: (session: string, error?: string) => Promise<void>;
 }
 
 declare const $: JQueryStatic;
@@ -73,12 +73,13 @@ export const Callbacks = (): Callbacks => {
     });
   };
 
-  const sendDone = (session: string): Promise<void> => {
+  const sendDone = (session: string, error?: string): Promise<void> => {
     // webpack makes this available
     const getCoverage = (): Record<string, any> => typeof Global.__coverage__ === 'undefined' ? {} : Global.__coverage__;
 
     return sendJson('/tests/done', {
       session,
+      error,
       coverage: getCoverage(),
     });
   };

--- a/modules/runner/src/main/ts/reporter/Reporter.ts
+++ b/modules/runner/src/main/ts/reporter/Reporter.ts
@@ -17,7 +17,7 @@ export interface TestReporter {
 export interface Reporter {
   readonly summary: () => { offset: number; passed: number; failed: number; skipped: number };
   readonly test: (file: string, name: string, totalNumTests: number) => TestReporter;
-  readonly done: () => void;
+  readonly done: (error?: LoggedError) => void;
 }
 
 export interface ReporterUi {
@@ -120,13 +120,14 @@ export const Reporter = (params: UrlParams, callbacks: Callbacks, ui: ReporterUi
     };
   };
 
-  const done = (): void => {
+  const done = (error?: LoggedError): void => {
     const setAsDone = (): void => {
       const totalTime = elapsed(initial);
       ui.done(totalTime);
     };
 
-    callbacks.sendDone(params.session).then(setAsDone, setAsDone);
+    const textError = error !== undefined ? ErrorReporter.text(error) : undefined;
+    callbacks.sendDone(params.session, textError).then(setAsDone, setAsDone);
   };
 
   return {

--- a/modules/runner/src/main/ts/runner/Runner.ts
+++ b/modules/runner/src/main/ts/runner/Runner.ts
@@ -1,4 +1,4 @@
-import { Suite } from '@ephox/bedrock-common';
+import { Failure, Suite } from '@ephox/bedrock-common';
 import { HarnessResponse } from '../core/ServerTypes';
 import { UrlParams } from '../core/UrlParams';
 import { noop } from '../core/Utils';
@@ -105,7 +105,7 @@ export const Runner = (rootSuite: Suite, params: UrlParams, callbacks: Callbacks
         // chain, so ensure we log it and report we've stopped running.
         if (e !== undefined) {
           console.error('Unexpected error occurred', e);
-          reporter.done();
+          reporter.done(Failure.prepFailure(e));
         }
       });
   };


### PR DESCRIPTION
Note: I haven't written any tests for the server part, as there are none. We're going to have to handle that tech debt one day though, so I'll log a JIRA so we can schedule it (see TINY-6898).