### PR TITLE
TINY-6970: Add .mjs file support

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 11.1.0
+
+* Added support for `.mjs` test files, overridden to load with webpack's `javascript/auto` type instead of `javascript/esm`
+
 Version 11.0.2
 
 * Fixed a regression introduced in 11.0.0 whereby --customRoutes couldn't be used in manual mode.

--- a/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
+++ b/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
@@ -97,7 +97,7 @@ export const testdir: ClOption = {
   alias: 'd',
   type: String,
   description: 'The directory containing all the files to test',
-  validate: Extraction.files(['Test.js', 'Test.bs.js', 'Test.ts', 'Test.tsx'])
+  validate: Extraction.files(['Test.js', 'Test.ts', 'Test.tsx', 'Test.mjs', 'Test.bs.js'])
 };
 
 export const testdirs: ClOption = {
@@ -108,7 +108,7 @@ export const testdirs: ClOption = {
   multiple: true,
   flatten: true,
   description: 'The directories (plural) containing all the files to test',
-  validate: Extraction.files(['Test.js', 'Test.bs.js', 'Test.ts', 'Test.tsx'])
+  validate: Extraction.files(['Test.js', 'Test.ts', 'Test.tsx', 'Test.mjs', 'Test.bs.js'])
 };
 
 export const projectdir = (currentDir: string): ClOption => {

--- a/modules/server/src/main/ts/bedrock/compiler/Imports.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Imports.ts
@@ -9,8 +9,7 @@ export const convertPolyfillNameToPath = (name: string): string => {
 
 const filePathToImport = (useRequire: boolean, scratchFile: string) => {
   return (filePath: string) => {
-    const importFilePath = path.join(path.dirname(filePath), path.basename(filePath, path.extname(filePath)));
-    let relativePath = path.relative(path.dirname(scratchFile), importFilePath);
+    let relativePath = path.relative(path.dirname(scratchFile), filePath);
 
     // make sure slashes are escaped for windows
     relativePath = relativePath.replace(/\\/g, '\\\\');

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -39,16 +39,15 @@ const webpackRemap: Array<Record<string, any>> = moduleAvailable('@ephox/swag') 
 
 const webpackSharedRules = webpackRemap.concat([
   {
-    test: /\.mjs$/,
+    test: /\.(mjs)$/,
     type: 'javascript/auto',
     use: []
   },
   {
-    test: /\.js|\.mjs$/,
+    test: /\.(js|mjs)$/,
     use: [ 'source-map-loader' ],
     enforce: 'pre'
   },
-
   {
     test: /\.(html|htm|css|bower|hex|rtf|xml|yml)$/,
     use: [ 'raw-loader' ]
@@ -92,7 +91,7 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
     module: {
       rules: webpackSharedRules.concat([
         {
-          test: /\.tsx?$/,
+          test: /\.(tsx?)$/,
           use: [
             {
               loader: 'ts-loader',
@@ -114,7 +113,7 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
       ]).concat(
         coverage ? [
           {
-            test: /\.tsx?$/,
+            test: /\.(tsx?)$/,
             enforce: 'post',
             loader: 'istanbul-instrumenter-loader',
             include: coverage.map((p) => path.resolve(p)),
@@ -173,7 +172,7 @@ const getWebPackConfigJs = (scratchFile: string, dest: string, coverage: string[
       rules: webpackSharedRules.concat(
         coverage ? [
           {
-            test: /\.js|\.mjs?$/,
+            test: /\.(js|mjs)$/,
             enforce: 'post',
             loader: 'istanbul-instrumenter-loader',
             include: coverage.map((p) => path.resolve(p)),

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -32,10 +32,28 @@ const moduleAvailable = (name: string) => {
 
 const webpackRemap: Array<Record<string, any>> = moduleAvailable('@ephox/swag') ? [
   {
-    test: /\.js|\.tsx?$/,
+    test: /\.js|\.mjs|\.tsx?$/,
     use: [ '@ephox/swag/webpack/remapper' ]
   }
 ] : [];
+
+const webpackSharedRules = webpackRemap.concat([
+  {
+    test: /\.mjs$/,
+    type: 'javascript/auto',
+    use: []
+  },
+  {
+    test: /\.js|\.mjs$/,
+    use: [ 'source-map-loader' ],
+    enforce: 'pre'
+  },
+
+  {
+    test: /\.(html|htm|css|bower|hex|rtf|xml|yml)$/,
+    use: [ 'raw-loader' ]
+  }
+]);
 
 const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: string, coverage: string[], manualMode: boolean, basedir: string): webpack.Configuration => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -51,13 +69,13 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
     },
 
     resolve: {
-      extensions: [ '.ts', '.tsx', '.js' ],
+      extensions: [ '.ts', '.tsx', '.js', '.mjs' ],
       plugins: [
         new TsConfigPathsPlugin({
           configFile: tsConfigFile,
           // awesome-typescript-loader could read this from above, but the new plugin can't?
           // lol whatever
-          extensions: [ '.ts', '.tsx', '.js' ]
+          extensions: [ '.ts', '.tsx', '.js', '.mjs' ]
         })
       ]
     },
@@ -72,13 +90,7 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
     },
 
     module: {
-      rules: webpackRemap.concat([
-        {
-          test: /\.js$/,
-          use: [ 'source-map-loader' ],
-          enforce: 'pre'
-        },
-
+      rules: webpackSharedRules.concat([
         {
           test: /\.tsx?$/,
           use: [
@@ -98,11 +110,6 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
               }
             }
           ]
-        },
-
-        {
-          test: /\.(html|htm|css|bower|hex|rtf|xml|yml)$/,
-          use: [ 'raw-loader' ]
         }
       ]).concat(
         coverage ? [
@@ -150,7 +157,7 @@ const getWebPackConfigJs = (scratchFile: string, dest: string, coverage: string[
     },
 
     resolve: {
-      extensions: [ '.js' ]
+      extensions: [ '.js', '.mjs' ]
     },
 
     // Webpack by default only resolves from the ./node_modules directory which will cause issues if the project that uses bedrock
@@ -163,20 +170,10 @@ const getWebPackConfigJs = (scratchFile: string, dest: string, coverage: string[
     },
 
     module: {
-      rules: webpackRemap.concat([
-        {
-          test: /\.js$/,
-          use: [ 'source-map-loader' ],
-          enforce: 'pre'
-        },
-        {
-          test: /\.(html|htm|css|bower|hex|rtf|xml|yml)$/,
-          use: [ 'raw-loader' ]
-        }
-      ]).concat(
+      rules: webpackSharedRules.concat(
         coverage ? [
           {
-            test: /\.js?$/,
+            test: /\.js|\.mjs?$/,
             enforce: 'post',
             loader: 'istanbul-instrumenter-loader',
             include: coverage.map((p) => path.resolve(p)),

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -32,7 +32,7 @@ const moduleAvailable = (name: string) => {
 
 const webpackRemap: Array<Record<string, any>> = moduleAvailable('@ephox/swag') ? [
   {
-    test: /\.js|\.mjs|\.tsx?$/,
+    test: /\.(js|mjs|tsx?)$/,
     use: [ '@ephox/swag/webpack/remapper' ]
   }
 ] : [];

--- a/modules/server/src/test/ts/compiler/ImportsTest.ts
+++ b/modules/server/src/test/ts/compiler/ImportsTest.ts
@@ -25,7 +25,7 @@ describe('Imports.generateImports', () => {
         filenames.forEach((filename) => {
           assert.include(imports, `
 __currentTestFile = "/${filename}.ts";
-require("${filename}");
+require("${filename}.ts");
 addTest("/${filename}.ts");`
           );
         });
@@ -37,7 +37,7 @@ addTest("/${filename}.ts");`
         filenames.forEach((filename) => {
           assert.include(imports, `
 __currentTestFile = "/${filename}.ts";
-import "${filename}";
+import "${filename}.ts";
 addTest("/${filename}.ts");`
           );
         });
@@ -51,7 +51,7 @@ addTest("/${filename}.ts");`
         filenames.forEach((filename) => {
           assert.include(imports, `
 __currentTestFile = "/${filename}.js";
-require("${filename}");
+require("${filename}.js");
 addTest("/${filename}.js");`
           );
         });
@@ -63,8 +63,33 @@ addTest("/${filename}.js");`
         filenames.forEach((filename) => {
           assert.include(imports, `
 __currentTestFile = "/${filename}.js";
-import "${filename}";
+import "${filename}.js";
 addTest("/${filename}.js");`
+          );
+        });
+      });
+    });
+  });
+  context('ESM', () => {
+    it('should include the specified test files (require)', () => {
+      withGenerateFilenames(true, 'mjs', (imports, filenames) => {
+        filenames.forEach((filename) => {
+          assert.include(imports, `
+__currentTestFile = "/${filename}.mjs";
+require("${filename}.mjs");
+addTest("/${filename}.mjs");`
+          );
+        });
+      });
+    });
+
+    it('should include the specified test files (import)', () => {
+      withGenerateFilenames(false, 'mjs', (imports, filenames) => {
+        filenames.forEach((filename) => {
+          assert.include(imports, `
+__currentTestFile = "/${filename}.mjs";
+import "${filename}.mjs";
+addTest("/${filename}.mjs");`
           );
         });
       });

--- a/modules/server/src/test/ts/compiler/ImportsTest.ts
+++ b/modules/server/src/test/ts/compiler/ImportsTest.ts
@@ -70,6 +70,7 @@ addTest("/${filename}.js");`
       });
     });
   });
+
   context('ESM', () => {
     it('should include the specified test files (require)', () => {
       withGenerateFilenames(true, 'mjs', (imports, filenames) => {


### PR DESCRIPTION
We are in the process of switching to `.mjs` files in RTC in order to satisfy the NodeJS requirements for using a mixed ESM/CJS environment.

However Webpack applies a very strict `javascript/esm` type to `.mjs` files which make it much more difficult to import CommonJS modules. The error that it throws is `Can't import the named export <blah> from non EcmaScript module (only default export is available)`. That's not easy to google for, many have had this issue and it took a while to track down the best workaround. The solution is to redefine `.mjs` files as the more general `javascript/auto` type.

This PR makes a few changes:

* Adds `Test.mjs` to the CLI `testdir` extension search list
  * Side note: we can potentially remove `Test.bs.js` now but that extension might be useful for other ReScript projects
* Adjusts the generated import code to use the full file path (this won't break existing projects but is essential for `.mjs`)
* Adds `.mjs` as a supported Webpack file extension everywhere `.js` is available
* Refactors the webpack rules common to TS and JS projects
* Overrides the `.mjs` file type as `javascript/auto`