### PR TITLE
TINY-7039: Enable the mouse position reset logic on Microsoft Edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 11.2.0 - 2021-03-05
+
+### Changed
+- The mouse position reset feature, when running in `auto` mode, now also works on Microsoft Edge.
+
 ## 11.1.1 - 2021-03-02
 
 ### Fixed

--- a/modules/server/src/main/ts/bedrock/server/Apis.ts
+++ b/modules/server/src/main/ts/bedrock/server/Apis.ts
@@ -71,7 +71,8 @@ export const create = (master: DriverMaster | null, maybeDriver: Attempt<any, Br
   const setInitialMousePosition = (driver: BrowserObject) => {
     return () => {
       // TODO re-enable resetting the mouse on other browsers when mouseMove gets fixed on Firefox/IE
-      if (driver.capabilities.browserName === 'chrome') {
+      const browserName = driver.capabilities.browserName;
+      if (browserName === 'chrome' || browserName === 'msedge') {
         return EffectUtils.getTarget(driver, {selector: '.bedrock-mouse-reset'}).then((target) => {
           return target.moveTo();
         });


### PR DESCRIPTION
This makes Chrome Edge match how Chrome works when running tests and also fixes some flakes we've been seeing lately.