### PR TITLE
Added support to print coloured output in the terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 11.3.0 - 2021-06-02
+
 ### Improved
 - The error messages printed to the terminal will now be coloured and syntax highlighted.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- The error messages printed to the terminal will now be coloured and syntax highlighted.
+
 ### Changed
 - The legacy assertion module now throws an `AssertionError` instead of a generic `Error`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- The legacy assertion module now throws an `AssertionError` instead of a generic `Error`.
+
+### Deprecated
+- Formally deprecated the legacy assertion module.
+
 ## 11.2.1 - 2021-05-31
 
 ### Fixed

--- a/modules/client/src/main/ts/api/LegacyAssert.ts
+++ b/modules/client/src/main/ts/api/LegacyAssert.ts
@@ -1,13 +1,19 @@
 import { TestLabel } from '@ephox/bedrock-common';
 import * as Compare from '../core/Compare';
 
+/** @deprecated Use chai assertions or the Assert module instead */
 const eq = function (expected: any, actual: any, message?: TestLabel): void {
   const result = Compare.compare(expected, actual);
   if (!result.eq) {
-    throw new Error(TestLabel.asStringOr(message, result.why));
+    const error: any = new Error(TestLabel.asStringOr(message, result.message));
+    error.name = 'AssertionError';
+    error.actual = actual;
+    error.expected = expected;
+    throw error;
   }
 };
 
+/** @deprecated Use chai assertions or the Assert module instead */
 const throws = function (f: () => void, expected?: string, message?: TestLabel): void {
   const token = {};
 
@@ -25,6 +31,7 @@ const throws = function (f: () => void, expected?: string, message?: TestLabel):
   }
 };
 
+/** @deprecated Use chai assertions or the Assert module instead */
 const throwsError = function (f: () => void, expected?: string, message?: TestLabel): void {
   const token = {};
 
@@ -42,6 +49,7 @@ const throwsError = function (f: () => void, expected?: string, message?: TestLa
   }
 };
 
+/** @deprecated Use chai assertions or the Assert module instead */
 const succeeds = function (f: () => void, message?: TestLabel): void {
   try {
     f();
@@ -50,6 +58,7 @@ const succeeds = function (f: () => void, message?: TestLabel): void {
   }
 };
 
+/** @deprecated Use chai assertions or the Assert module instead */
 const fail = function (message?: TestLabel): void {
   throw new Error(TestLabel.asStringOr(message, () => 'Test failed'));
 };

--- a/modules/client/src/main/ts/core/Compare.ts
+++ b/modules/client/src/main/ts/core/Compare.ts
@@ -13,13 +13,14 @@ const Obj = {
 export interface Comparison {
   eq: boolean;
   why: () => string;
+  message: () => string;
 }
 
 const pass = (): Comparison =>
-  ({ eq: true, why: () => '' });
+  ({ eq: true, why: () => '', message: () => '' });
 
 const fail = (why: () => string): Comparison =>
-  ({ eq: false, why });
+  ({ eq: false, why, message: why });
 
 const failCompare = (x: any, y: any, prefix?: string): Comparison => {
   return fail(() => (prefix || 'Values were different') + ': [' + String(x) + '] vs [' + String(y) + ']');
@@ -110,6 +111,7 @@ export const compare = (x: any, y: any): Comparison => {
 
   return {
     eq: result.eq,
-    why: () => result.why() + '\n' + bar + '\n' + JSON.stringify(x) + '\n' + bar + '\n' + JSON.stringify(y) + '\n' + bar + '\n'
+    why: () => result.why() + '\n' + bar + '\n' + JSON.stringify(x) + '\n' + bar + '\n' + JSON.stringify(y) + '\n' + bar + '\n',
+    message: result.why
   };
 };

--- a/modules/common/src/main/ts/api/ErrorExtractor.ts
+++ b/modules/common/src/main/ts/api/ErrorExtractor.ts
@@ -1,0 +1,109 @@
+import * as Differ from './Differ';
+import * as TestError from './TestError';
+import * as LoggedError from './LoggedError';
+
+type LoggedError = LoggedError.LoggedError;
+
+type TestError = TestError.TestError;
+type PprintAssertionError = TestError.PprintAssertionError;
+type HtmlDiffAssertionError = TestError.HtmlDiffAssertionError;
+type AssertionError = TestError.AssertionError;
+
+export interface BasicErrorData {
+  readonly type: string;
+  readonly message: string;
+  readonly diff?: {
+    readonly expected: string;
+    readonly actual: string;
+    readonly comparison: string;
+  };
+}
+
+export interface ErrorData extends BasicErrorData {
+  readonly logs?: string;
+  readonly stack?: string;
+}
+
+const stringify = (e: any) => {
+  if (e === undefined) {
+    return 'undefined';
+  } else if (typeof e === 'string') {
+    return e;
+  } else {
+    return JSON.stringify(e);
+  }
+};
+
+const extractError = (err?: LoggedError): TestError =>
+  err === undefined ? new Error('no error given') : err;
+
+const extractStack = (e: TestError): string => {
+  if (e.stack) {
+    return e.stack.split('\n')
+      .filter((line) => line.indexOf('at') !== -1)
+      .join('\n');
+  } else {
+    return '';
+  }
+};
+
+const extractErrorData = (e: HtmlDiffAssertionError | PprintAssertionError): BasicErrorData => {
+  const actual = e.diff.actual;
+  const expected = e.diff.expected;
+  const comparison = TestError.isHTMLDiffError(e) ? e.diff.comparison : Differ.diffPrettyText(actual, expected);
+  return ({
+    type: e.name,
+    message: `Test failure: ${e.message}`,
+    diff: {
+      actual,
+      expected,
+      comparison
+    }
+  });
+};
+
+const extractAssertionErrorData = (e: AssertionError): BasicErrorData => {
+  const actual = stringify(e.actual);
+  const expected = stringify(e.expected);
+  const message = `Assertion error: ${e.message ?? ''}`;
+  if (e.showDiff !== false) {
+    return {
+      type: e.name,
+      message,
+      diff: {
+        expected,
+        actual,
+        comparison: Differ.diffPrettyText(actual, expected)
+      }
+    };
+  } else {
+    return { type: e.name, message };
+  }
+};
+
+export const getBasicErrorData = (e: TestError): BasicErrorData => {
+  if (TestError.isHTMLDiffError(e) || TestError.isPprintAssertionError(e)) {
+    return extractErrorData(e);
+  } else if (TestError.isAssertionError(e)) {
+    return extractAssertionErrorData(e);
+  } else if (e.name && e.message) {
+    return { type: 'Error', message: e.name + ': ' + e.message };
+  } else if (e.toString !== undefined) {
+    return { type: 'Error', message: String(e) };
+  } else {
+    return { type: 'Error', message: JSON.stringify(e) };
+  }
+};
+
+export const getErrorData = (err: LoggedError): ErrorData => {
+  const e = extractError(err);
+  const formattedLogs = err.logs && err.logs.length > 0 ? err.logs.map((log) => log
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+  ).join('\n') : undefined;
+  return {
+    ...getBasicErrorData(e),
+    stack: extractStack(e),
+    logs: formattedLogs
+  };
+};

--- a/modules/common/src/main/ts/api/Main.ts
+++ b/modules/common/src/main/ts/api/Main.ts
@@ -1,3 +1,4 @@
+import { ErrorData } from './ErrorExtractor';
 import * as Failure from './Failure';
 import { Global } from './Global';
 import * as LoggedError from './LoggedError';
@@ -14,6 +15,7 @@ export {
   Global,
   TestError,
   LoggedError,
+  ErrorData,
   Reporter,
   TestLabel,
   TestLogs,

--- a/modules/common/src/main/ts/api/TestError.ts
+++ b/modules/common/src/main/ts/api/TestError.ts
@@ -38,7 +38,7 @@ export const pprintAssertionError = (message: string, expected: string, actual: 
     expected
   };
   e.toString = (): string => {
-    return Reporter.pprintAssertionErrorText(e as PprintAssertionError);
+    return Reporter.pprintAssertionError(e as PprintAssertionError);
   };
   return e as PprintAssertionError;
 };

--- a/modules/common/src/test/ts/api/ReporterTest.ts
+++ b/modules/common/src/test/ts/api/ReporterTest.ts
@@ -75,10 +75,12 @@ describe('Reporter', () => {
       // NOTE: the <ins> and <del> are supposed to remain
       const expected =
         'Test failure: message&quot;\n' +
-        'Expected: abc&quot;hello&quot;\n' +
-        'Actual: ab&quot;hello&quot;\n' +
-        '\n' +
-        'HTML Diff: <ins>blah</ins><del>hello</del>&quot;hello&quot;&lt;span&gt;\n' +
+        'Expected:\n' +
+        'abc&quot;hello&quot;\n' +
+        'Actual:\n' +
+        'ab&quot;hello&quot;\n' +
+        'Diff:\n' +
+        '<ins>blah</ins><del>hello</del>&quot;hello&quot;&lt;span&gt;\n' +
         '\n' +
         'Stack:\n';
       assert.deepEqual(cleanStack(actual), expected, 'Error message');
@@ -93,10 +95,12 @@ describe('Reporter', () => {
       const actual = Reporter.text(LoggedError.loggedError(e, []));
       const expected =
         'Test failure: message"\n' +
-        'Expected: abc"hello"\n' +
-        'Actual: ab"hello"\n' +
-        '\n' +
-        'HTML Diff: <ins>blah</ins><del>hello</del>"hello"<span>\n' +
+        'Expected:\n' +
+        'abc"hello"\n' +
+        'Actual:\n' +
+        'ab"hello"\n' +
+        'Diff:\n' +
+        '<ins>blah</ins><del>hello</del>"hello"<span>\n' +
         '\n' +
         'Stack:\n';
       assert.deepEqual(cleanStack(actual), expected, 'Error message');
@@ -117,6 +121,27 @@ describe('Reporter', () => {
         'ab&quot;hello&quot;\n' +
         'Diff:\n' +
         '<del style="background:#ffe6e6;">ab&quot;hello&quot;</del><br /><ins style="background:#e6ffe6;">abc&quot;hello&quot;</ins><br />\n' +
+        '\n' +
+        'Stack:\n';
+      assert.deepEqual(cleanStack(actual), expected, 'Error message');
+    }
+  });
+
+  it('Reports thrown AssertionError errors as text', () => {
+    try {
+      // noinspection ExceptionCaughtLocallyJS
+      throw assertion();
+    } catch (e) {
+      const actual = Reporter.text(LoggedError.loggedError(e, []));
+      const expected =
+        'Assertion error: message"\n' +
+        'Expected:\n' +
+        'abc"hello"\n' +
+        'Actual:\n' +
+        'ab"hello"\n' +
+        'Diff:\n' +
+        '- | ab"hello"\n' +
+        '+ | abc"hello"\n' +
         '\n' +
         'Stack:\n';
       assert.deepEqual(cleanStack(actual), expected, 'Error message');

--- a/modules/runner/src/main/ts/reporter/Callbacks.ts
+++ b/modules/runner/src/main/ts/reporter/Callbacks.ts
@@ -1,12 +1,17 @@
-import { Global } from '@ephox/bedrock-common';
+import { ErrorData, Global } from '@ephox/bedrock-common';
 import Promise from '@ephox/wrap-promise-polyfill';
 import { HarnessResponse } from '../core/ServerTypes';
+
+export interface TestErrorData {
+  readonly data: ErrorData;
+  readonly text: string;
+}
 
 export interface Callbacks {
   readonly loadHarness: () => Promise<HarnessResponse>
   readonly sendKeepAlive: (session: string) => Promise<void>;
   readonly sendTestStart: (session: string, totalTests: number, file: string, name: string) => Promise<void>;
-  readonly sendTestResult: (session: string, file: string, name: string, passed: boolean, time: string, error: string | null, skipped: string | null) => Promise<void>;
+  readonly sendTestResult: (session: string, file: string, name: string, passed: boolean, time: string, error: TestErrorData | null, skipped: string | null) => Promise<void>;
   readonly sendDone: (session: string, error?: string) => Promise<void>;
 }
 
@@ -61,7 +66,7 @@ export const Callbacks = (): Callbacks => {
     });
   };
 
-  const sendTestResult = (session: string, file: string, name: string, passed: boolean, time: string, error: string | null, skipped: string | null): Promise<void> => {
+  const sendTestResult = (session: string, file: string, name: string, passed: boolean, time: string, error: TestErrorData | null, skipped: string | null): Promise<void> => {
     return sendJson('/tests/result', {
       session,
       file,

--- a/modules/runner/src/main/ts/reporter/Reporter.ts
+++ b/modules/runner/src/main/ts/reporter/Reporter.ts
@@ -103,11 +103,15 @@ export const Reporter = (params: UrlParams, callbacks: Callbacks, ui: ReporterUi
         reported = true;
         failCount++;
 
-        const textError = ErrorReporter.text(e);
+        const errorData = ErrorReporter.data(e);
+        const error = {
+          data: errorData,
+          text: ErrorReporter.dataText(errorData)
+        };
         const testTime = elapsed(starttime);
 
         testUi.fail(e, testTime, currentCount);
-        return callbacks.sendTestResult(params.session, file, name, false, testTime, textError, null);
+        return callbacks.sendTestResult(params.session, file, name, false, testTime, error, null);
       }
     };
 

--- a/modules/runner/src/test/ts/reporter/ReporterTest.ts
+++ b/modules/runner/src/test/ts/reporter/ReporterTest.ts
@@ -4,7 +4,7 @@ import { assert } from 'chai';
 import * as fc from 'fast-check';
 import { beforeEach, describe, it } from 'mocha';
 import { UrlParams } from '../../../main/ts/core/UrlParams';
-import { Callbacks } from '../../../main/ts/reporter/Callbacks';
+import { Callbacks, TestErrorData } from '../../../main/ts/reporter/Callbacks';
 import { Reporter } from '../../../main/ts/reporter/Reporter';
 import { noop } from '../TestUtils';
 
@@ -21,7 +21,7 @@ interface EndTestData {
   readonly name: string;
   readonly passed: boolean;
   readonly time: string;
-  readonly error: string | null;
+  readonly error: TestErrorData | null;
   readonly skipped: string | null;
 }
 
@@ -177,7 +177,7 @@ describe('Reporter.test', () => {
           assert.isFalse(data.passed);
           assert.isNull(data.skipped);
           assert.isString(data.time);
-          assert.equal(data.error, 'Error: Failed\n\nLogs:\nLog Message');
+          assert.equal(data.error?.text, 'Error: Failed\n\nLogs:\nLog Message');
 
           assert.deepEqual(reporter.summary(), {
             offset,

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -18,6 +18,8 @@
     "@ephox/bedrock-common": "^11.2.1",
     "@ephox/bedrock-runner": "^11.2.1",
     "async": "^3.0.0",
+    "chalk": "^4.1.1",
+    "cli-highlight": "^2.1.11",
     "command-line-args": "^5.0.0",
     "command-line-usage": "^6.0.0",
     "core-js": "^3.6.4",

--- a/modules/server/src/main/ts/BedrockAuto.ts
+++ b/modules/server/src/main/ts/BedrockAuto.ts
@@ -23,7 +23,7 @@ export const go = (bedrockAutoSettings: BedrockAutoSettings): void => {
   const routes = RunnerRoutes.generate('auto', settings.projectdir, settings.basedir, settings.config, settings.bundler, settings.testfiles, settings.chunk, settings.retries, settings.singleTimeout, settings.stopOnFailure, basePage, settings.coverage, settings.polyfills);
 
   routes.then((runner) => {
-    Driver.create({
+    return Driver.create({
       browser: settings.browser,
       basedir: settings.basedir,
       debuggingPort: settings.debuggingPort,
@@ -66,14 +66,14 @@ export const go = (bedrockAutoSettings: BedrockAutoSettings): void => {
 
         return Lifecycle.shutdown(result, webdriver, done, gruntDone, delayExit);
       });
-    }).catch((err) => {
-      console.error(chalk.red(err));
-      if (settings.gruntDone !== undefined) {
-        settings.gruntDone(false);
-      } else {
-        process.exit(ExitCodes.failures.unexpected);
-      }
     });
+  }).catch((err) => {
+    console.error(chalk.red(err));
+    if (settings.gruntDone !== undefined) {
+      settings.gruntDone(false);
+    } else {
+      process.exit(ExitCodes.failures.unexpected);
+    }
   });
 };
 

--- a/modules/server/src/main/ts/BedrockAuto.ts
+++ b/modules/server/src/main/ts/BedrockAuto.ts
@@ -1,3 +1,4 @@
+import * as chalk from 'chalk';
 import * as Serve from './bedrock/server/Serve';
 import { Attempt } from './bedrock/core/Attempt';
 import * as Version from './bedrock/core/Version';
@@ -66,9 +67,12 @@ export const go = (bedrockAutoSettings: BedrockAutoSettings): void => {
         return Lifecycle.shutdown(result, webdriver, done, gruntDone, delayExit);
       });
     }).catch((err) => {
-      console.error(err);
-      if (settings.gruntDone !== undefined) settings.gruntDone(false);
-      else process.exit(ExitCodes.failures.unexpected);
+      console.error(chalk.red(err));
+      if (settings.gruntDone !== undefined) {
+        settings.gruntDone(false);
+      } else {
+        process.exit(ExitCodes.failures.unexpected);
+      }
     });
   });
 };

--- a/modules/server/src/main/ts/bedrock/cli/Clis.ts
+++ b/modules/server/src/main/ts/bedrock/cli/Clis.ts
@@ -1,3 +1,4 @@
+import * as chalk from 'chalk';
 import * as cli from './Cli';
 import * as ClOptions from './ClOptions';
 import { ExitCodes } from '../util/ExitCodes';
@@ -55,9 +56,9 @@ export const forManual = (directories: Directories, argv: string[] = process.arg
 };
 
 export const logAndExit = (errs: cli.CliError): void => {
-  console.error('\n****\nError while processing command line for ' + errs.command);
+  console.error(chalk.red('\n****\nError while processing command line for ' + errs.command));
   const messages = errs.errors.join('\n');
-  console.error(messages);
-  console.error('Use ' + errs.command + ' --help to print usage\n****\n');
+  console.error(chalk.red(messages));
+  console.error(chalk.red('Use ' + errs.command + ' --help to print usage\n****\n'));
   process.exit(ExitCodes.failures.cli);
 };

--- a/modules/server/src/main/ts/bedrock/core/ConsoleReporter.ts
+++ b/modules/server/src/main/ts/bedrock/core/ConsoleReporter.ts
@@ -1,9 +1,16 @@
-import { TestResults } from '../server/Controller';
+import { TestErrorData, TestResults } from '../server/Controller';
 
 const numberOfErrorsToPrint = 5;
 
-export const generateReport = (data: TestResults): string => {
+const formatError = (err: TestErrorData | null) => {
+  if (err === null) {
+    return '';
+  } else {
+    return err.text;
+  }
+};
 
+export const generateReport = (data: TestResults): string => {
   const results = data.results;
   const failures = results.filter((x) => !x.passed && !x.skipped);
 
@@ -14,7 +21,7 @@ export const generateReport = (data: TestResults): string => {
     toShow.forEach((f) => {
       r.push(line);
       r.push(`Test failed: ${f.name} (${f.file})`);
-      r.push(f.error);
+      r.push(formatError(f.error));
       r.push('');
     });
     r.push(line);

--- a/modules/server/src/main/ts/bedrock/core/ConsoleReporter.ts
+++ b/modules/server/src/main/ts/bedrock/core/ConsoleReporter.ts
@@ -1,12 +1,41 @@
+import * as chalk from 'chalk';
+import { highlight } from 'cli-highlight';
 import { TestErrorData, TestResults } from '../server/Controller';
 
 const numberOfErrorsToPrint = 5;
+
+const highlightDiff = (diff: string) =>
+  highlight(diff, { language: 'diff' });
+
+const formatExtra = (err: TestErrorData): string => {
+  const e = err.data;
+  if (e.logs !== undefined && e.logs.length > 0) {
+    return '\n\nLogs:\n' + chalk.gray(e.logs);
+  } else if (e.stack !== undefined && e.stack.length > 0) {
+    return '\n\nStack:\n' + chalk.gray(e.stack);
+  } else {
+    return '';
+  }
+};
+
+const formatDiff = (actual: string, expected: string, comparison: string) => {
+  return `Expected:
+${expected}
+Actual:
+${actual}
+Diff:
+${highlightDiff(comparison)}`;
+};
 
 const formatError = (err: TestErrorData | null) => {
   if (err === null) {
     return '';
   } else {
-    return err.text;
+    const data = err.data;
+    const message = chalk.red(data.message);
+    const diff = data.diff ? '\n' + formatDiff(data.diff.actual, data.diff.expected, data.diff.comparison) : '';
+    const extra = formatExtra(err);
+    return `${message}${diff}${extra}`;
   }
 };
 

--- a/modules/server/src/main/ts/bedrock/core/Lifecycle.ts
+++ b/modules/server/src/main/ts/bedrock/core/Lifecycle.ts
@@ -1,3 +1,4 @@
+import * as chalk from 'chalk';
 import { BrowserObject } from 'webdriverio';
 import { TestResult } from '../server/Controller';
 import { ExitCodes } from '../util/ExitCodes';
@@ -20,16 +21,16 @@ export const shutdown = (promise: Promise<Attempt<string[], TestResult[]>>, driv
 
     return delay.then(() => {
       return Attempt.cata(res, (errs) => {
-        console.log(errs.join('\n'));
+        console.log(chalk.red(errs.join('\n')));
         return done().then(exit(ExitCodes.failures.tests));
       }, () => {
-        console.log('All tests passed.');
+        console.log(chalk.green('All tests passed.'));
         return done().then(exit(ExitCodes.success));
       });
     });
   }).catch((err) => {
     return exitDelay().then(() => {
-      console.error('********** Unexpected Bedrock Error -> Server Quitting **********');
+      console.error(chalk.red('********** Unexpected Bedrock Error -> Server Quitting **********'));
       console.error(err);
       return done().then(exit(ExitCodes.failures.unexpected));
     });

--- a/modules/server/src/main/ts/bedrock/core/Reporter.ts
+++ b/modules/server/src/main/ts/bedrock/core/Reporter.ts
@@ -19,17 +19,16 @@ const outputTime = (runnerTime: string) => {
  * in the middle of this token. Jenkins seems fine with multiple CDATA sections within a <failure> tag.
  * @param s
  */
-export const splitCdatas =
-  (s: string): string[] => {
-    const raw = s.split(/]]>/g);
-    return raw.map((x, i) => {
-      let r = '';
-      if (i > 0) r = '>' + r;
-      r = r + x;
-      if (i < raw.length - 1) r = r + ']]';
-      return r;
-    });
-  };
+export const splitCdatas = (s: string): string[] => {
+  const raw = s.split(/]]>/g);
+  return raw.map((x, i) => {
+    let r = '';
+    if (i > 0) r = '>' + r;
+    r = r + x;
+    if (i < raw.length - 1) r = r + ']]';
+    return r;
+  });
+};
 
 export const write = (settings: ReporterSettings) => {
   return (data: TestResults): Promise<Attempt<string[], TestResult[]>> => {
@@ -90,7 +89,7 @@ export const write = (settings: ReporterSettings) => {
             elem.startElement('failure')
               .writeAttribute('Test FAILED: some failed assert')
               .writeAttribute('type', 'failure');
-            const cdatas = splitCdatas(res.error);
+            const cdatas = splitCdatas(res.error?.text ?? '');
             cdatas.forEach((c) => elem.writeCData(c));
             elem.endElement();
           }

--- a/modules/server/src/main/ts/bedrock/server/Controller.ts
+++ b/modules/server/src/main/ts/bedrock/server/Controller.ts
@@ -1,5 +1,11 @@
+import { ErrorData } from '@ephox/bedrock-common';
 import * as Hud from '../cli/Hud';
 import * as Type from '../util/Type';
+
+export interface TestErrorData {
+  readonly data: ErrorData;
+  readonly text: string;
+}
 
 export interface TestResult {
   readonly name: string;
@@ -7,7 +13,7 @@ export interface TestResult {
   readonly passed: boolean;
   readonly time: string;
   readonly skipped: string;
-  readonly error: string;
+  readonly error: TestErrorData | null;
 }
 
 export interface TestResults {
@@ -44,7 +50,7 @@ export interface Controller {
   readonly enableHud: () => void;
   readonly recordAlive: (sessionId: string) => void;
   readonly recordTestStart: (id: string, name: string, file: string, totalTests: number) => void;
-  readonly recordTestResult: (id: string, name: string, file: string, passed: boolean, time: string, error: string, skipped: string) => void;
+  readonly recordTestResult: (id: string, name: string, file: string, passed: boolean, time: string, error: TestErrorData | null, skipped: string) => void;
   readonly recordDone: (id: string, error?: string) => void;
   readonly awaitDone: () => Promise<TestResults>;
 }
@@ -127,7 +133,7 @@ export const create = (stickyFirstSession: boolean, singleTimeout: number, overa
     updateHud(session);
   };
 
-  const recordTestResult = (id: string, name: string, file: string, passed: boolean, time: string, error: string, skipped: string) => {
+  const recordTestResult = (id: string, name: string, file: string, passed: boolean, time: string, error: TestErrorData | null, skipped: string) => {
     const now = Date.now();
     const session = getSession(id);
     const record = { name, file, passed, time, error, skipped };

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,14 +987,9 @@
   integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
 
 "@types/chai@^4.2.14":
-  version "4.2.14"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.14.tgz#44d2dd0b5de6185089375d976b4ec5caf6861193"
-  integrity sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
-
-"@types/color-name@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
-  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+  version "4.2.18"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.18.tgz#0c8e298dbff8205e2266606c1ea5fbdba29b46e4"
+  integrity sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==
 
 "@types/command-line-args@^5.0.0":
   version "5.0.0"
@@ -1734,12 +1729,11 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
-  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
-    "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
 any-promise@^1.0.0:
@@ -2528,15 +2522,15 @@ caseless@~0.12.0:
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 chai@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
-  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"
+  integrity sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==
   dependencies:
     assertion-error "^1.1.0"
     check-error "^1.0.2"
     deep-eql "^3.0.1"
     get-func-name "^2.0.0"
-    pathval "^1.1.0"
+    pathval "^1.1.1"
     type-detect "^4.0.5"
 
 chalk@^1.1.3:
@@ -2559,10 +2553,10 @@ chalk@^2.0.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@~4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+chalk@^4.0.0, chalk@^4.1.1, chalk@~4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -2665,6 +2659,18 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-highlight@^2.1.11:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.11.tgz#49736fa452f0aaf4fae580e30acb26828d2dc1bf"
+  integrity sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==
+  dependencies:
+    chalk "^4.0.0"
+    highlight.js "^10.7.1"
+    mz "^2.4.0"
+    parse5 "^5.1.1"
+    parse5-htmlparser2-tree-adapter "^6.0.0"
+    yargs "^16.0.0"
+
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
@@ -2678,6 +2684,15 @@ cliui@^5.0.0:
     string-width "^3.1.0"
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-deep@^4.0.1:
   version "4.0.1"
@@ -3538,6 +3553,11 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
 emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
@@ -3644,6 +3664,11 @@ es6-promisify@^5.0.0:
   integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -4401,7 +4426,7 @@ genfun@^5.0.0:
   resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
   integrity sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -4855,6 +4880,11 @@ he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+highlight.js@^10.7.1:
+  version "10.7.2"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.2.tgz#89319b861edc66c48854ed1e6da21ea89f847360"
+  integrity sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -5357,6 +5387,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-glob@^3.1.0:
   version "3.1.0"
@@ -6509,7 +6544,7 @@ mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mz@^2.5.0:
+mz@^2.4.0, mz@^2.5.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
   integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
@@ -7147,6 +7182,23 @@ parse-url@^5.0.0:
     parse-path "^4.0.0"
     protocols "^1.4.0"
 
+parse5-htmlparser2-tree-adapter@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
+parse5@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
+parse5@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -7247,10 +7299,10 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pathval@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 pbkdf2@^3.0.3:
   version "3.1.1"
@@ -8623,6 +8675,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string.prototype.trimend@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
@@ -9649,6 +9710,15 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -9729,6 +9799,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
@@ -9757,6 +9832,11 @@ yargs-parser@^18.1.3:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2:
+  version "20.2.7"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
+  integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
 
 yargs-unparser@2.0.0:
   version "2.0.0"
@@ -9800,6 +9880,19 @@ yargs@^14.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
+
+yargs@^16.0.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
This is something I've been wanting to do as a "pet" project for quite a long time, as the errors reported via the terminal can be very hard to read. More than happy to change the colours I've used if anyone has better suggestions.

Description of changes:
- Reworked the error printing logic to generate a normalized `ErrorData` object from the various `Error` types. From that the errors can be formatted in a consistent way.
- Updated the runner and server to pass through the new `ErrorData` object instead of just a plain text string when a test fails. This also could open up the ability to have different reporters in the future if we want/need it.
- Changed the legacy assertion module to throw an Assertion error. This is done so that we can highlight the diff, as previously it was all part of the single message.
- Formally deprecated the old legacy assertion module so we see not to use it in an IDE.

Screenshots:

Success:
![image](https://user-images.githubusercontent.com/1575550/120085794-7cafae80-c11e-11eb-910c-637ad646065b.png)

Failure:
![image](https://user-images.githubusercontent.com/1575550/120085776-51c55a80-c11e-11eb-88dc-979259f96bc6.png)
