### PR TITLE
Minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 11.3.2 - 2021-08-11
+
+### Fixed
+- The runner was using incorrectly using unpolyfilled Promises.
+
 ## 11.3.1 - 2021-06-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 11.3.2 - 2021-08-11
+## 11.3.2 - 2021-08-12
 
 ### Fixed
 - The runner was using incorrectly using unpolyfilled Promises.
+- The first stack trace line was incorrectly removed on Firefox.
 
 ## 11.3.1 - 2021-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 11.3.2 - 2021-08-12
 
 ### Fixed
-- The runner was using incorrectly using unpolyfilled Promises.
+- The runner was incorrectly using unpolyfilled Promises.
 - The first stack trace line was incorrectly removed on Firefox.
 
 ## 11.3.1 - 2021-06-10

--- a/modules/common/src/main/ts/api/Failure.ts
+++ b/modules/common/src/main/ts/api/Failure.ts
@@ -18,8 +18,14 @@ const cleanStack = (error: Error, linesToRemove = 1) => {
 
   const lines = error.stack.split('\n');
   const message = lines[0];
-  const stack = lines.slice(1 + linesToRemove);
-  return message + '\n' + stack.join('\n');
+  // If the first line is the `normalizeError` function then we have no message (e.g. Firefox errors)
+  if (message.indexOf('normalizeError') !== -1) {
+    const stack = lines.slice(linesToRemove);
+    return stack.join('\n');
+  } else {
+    const stack = lines.slice(1 + linesToRemove);
+    return message + '\n' + stack.join('\n');
+  }
 };
 
 export const normalizeError = (err: TestThrowable): TestError => {

--- a/modules/runner/src/main/ts/api/Main.ts
+++ b/modules/runner/src/main/ts/api/Main.ts
@@ -1,4 +1,5 @@
 import { Failure, Global } from '@ephox/bedrock-common';
+import Promise from '@ephox/wrap-promise-polyfill';
 import * as Globals from '../core/Globals';
 import * as TestLoader from '../core/TestLoader';
 import { UrlParams } from '../core/UrlParams';

--- a/modules/runner/src/main/ts/runner/Runner.ts
+++ b/modules/runner/src/main/ts/runner/Runner.ts
@@ -1,4 +1,5 @@
 import { Suite } from '@ephox/bedrock-common';
+import Promise from '@ephox/wrap-promise-polyfill';
 import { HarnessResponse } from '../core/ServerTypes';
 import { UrlParams } from '../core/UrlParams';
 import { noop } from '../core/Utils';


### PR DESCRIPTION
This just fixes 2 minor issues I found when spiking out a new feature I want to implement for Bedrock (looking at improving stack traces). The first was there were 2 files we weren't using the Promise polyfill which meant the runner died on IE in specific cases. The second is that on Firefox the stacktrace starts on line 0, not line 1 like other browsers so we were losing the first entry.

Note: We can't use automated tests for either of these as the tests run using Node.js.