### PR TITLE
TINY-7869: Add sourcemap resolution for stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 11.4.0 - 2021-08-25
+
+### Improved
+- Stack traces for failed tests will now be resolved using the sourcemap where possible.
+
 ## 11.3.3 - 2021-08-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 11.4.0 - 2021-08-25
+## 11.4.0 - 2021-08-24
 
 ### Improved
 - Stack traces for failed tests will now be resolved using the sourcemap where possible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 11.4.0 - 2021-08-24
+## 11.4.0 - 2021-08-25
 
 ### Improved
 - Stack traces for failed tests will now be resolved using the sourcemap where possible.

--- a/modules/runner/package.json
+++ b/modules/runner/package.json
@@ -22,7 +22,8 @@
     "rollup": "^1.20.2",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-sourcemaps": "^0.4.2"
+    "rollup-plugin-sourcemaps": "^0.4.2",
+    "sourcemapped-stacktrace": "^1.1.11"
   },
   "main": "./lib/main/ts/api/Main.js",
   "module": "./lib/main/ts/api/Main.js",

--- a/modules/runner/src/main/ts/core/Utils.ts
+++ b/modules/runner/src/main/ts/core/Utils.ts
@@ -1,4 +1,6 @@
 import { Suite, Test } from '@ephox/bedrock-common';
+import Promise from '@ephox/wrap-promise-polyfill';
+import sourceMappedStackTrace from 'sourcemapped-stacktrace';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const noop = (): void => {};
@@ -39,3 +41,17 @@ export const getFullTitle = (suiteOrTest: Suite | Test, separator: string): stri
 };
 
 export const makeSessionId = (): string => '' + Math.ceil((Math.random() * 100000000));
+
+export const mapStackTrace = (stack: string | undefined): Promise<string> => new Promise((resolve) => {
+  if (stack) {
+    // If the stack trace format can't be found then an Error will be thrown.
+    // In that case lets just return the original stack instead.
+    try {
+      sourceMappedStackTrace.mapStackTrace(stack, (stack) => resolve(stack.join('\n')));
+    } catch (e) {
+      resolve(stack);
+    }
+  } else {
+    resolve('');
+  }
+});

--- a/modules/runner/src/main/ts/reporter/Reporter.ts
+++ b/modules/runner/src/main/ts/reporter/Reporter.ts
@@ -2,7 +2,7 @@ import { LoggedError, Reporter as ErrorReporter } from '@ephox/bedrock-common';
 import Promise from '@ephox/wrap-promise-polyfill';
 import { Callbacks } from './Callbacks';
 import { UrlParams } from '../core/UrlParams';
-import { formatElapsedTime } from '../core/Utils';
+import { formatElapsedTime, mapStackTrace } from '../core/Utils';
 
 type LoggedError = LoggedError.LoggedError;
 
@@ -103,15 +103,18 @@ export const Reporter = (params: UrlParams, callbacks: Callbacks, ui: ReporterUi
         reported = true;
         failCount++;
 
-        const errorData = ErrorReporter.data(e);
-        const error = {
-          data: errorData,
-          text: ErrorReporter.dataText(errorData)
-        };
         const testTime = elapsed(starttime);
+        return mapStackTrace(e.stack).then((mappedStack) => {
+          e.stack = mappedStack;
+          const errorData = ErrorReporter.data(e);
+          const error = {
+            data: errorData,
+            text: ErrorReporter.dataText(errorData)
+          };
 
-        testUi.fail(e, testTime, currentCount);
-        return callbacks.sendTestResult(params.session, file, name, false, testTime, error, null);
+          testUi.fail(e, testTime, currentCount);
+          return callbacks.sendTestResult(params.session, file, name, false, testTime, error, null);
+        });
       }
     };
 

--- a/modules/runner/src/main/ts/reporter/Reporter.ts
+++ b/modules/runner/src/main/ts/reporter/Reporter.ts
@@ -124,7 +124,7 @@ export const Reporter = (params: UrlParams, callbacks: Callbacks, ui: ReporterUi
             text: ErrorReporter.dataText(errorData)
           };
 
-          testUi.fail(e, testTime, currentCount);
+          testUi.fail(err, testTime, currentCount);
           return callbacks.sendTestResult(params.session, file, name, false, testTime, error, null);
         });
       }

--- a/modules/runner/src/main/ts/reporter/Reporter.ts
+++ b/modules/runner/src/main/ts/reporter/Reporter.ts
@@ -37,7 +37,7 @@ const mapError = (e: LoggedError) => mapStackTrace(e.stack).then((mappedStack) =
   e.stack = mappedStack;
 
   // Logs may have the stack trace included as well, so ensure we replace that as well
-  if (e.logs !== undefined && originalStack !== undefined) {
+  if (e.logs !== undefined && e.logs.length > 0 && originalStack !== undefined) {
     const logs = e.logs.join('\n');
     e.logs = logs.replace(originalStack, mappedStack).split('\n');
   }

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -60,7 +60,7 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
   return {
     stats: 'none',
     entry: scratchFile,
-    devtool: manualMode ? 'source-map' : false,
+    devtool: 'source-map',
     mode: manualMode ? 'development' : 'none',
 
     optimization: {
@@ -148,7 +148,7 @@ const getWebPackConfigJs = (scratchFile: string, dest: string, coverage: string[
   return {
     stats: 'none',
     entry: scratchFile,
-    devtool: manualMode ? 'source-map' : false,
+    devtool: 'source-map',
     mode: manualMode ? 'development' : 'none',
 
     optimization: {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "lint": "yarn eslint 'modules/common/src/**/*.ts' 'modules/client/src/**/*.ts' 'modules/runner/src/**/*.ts' 'modules/server/src/**/*.ts' 'modules/server/tasks/**/*.js'",
     "prepublishOnly": "yarn build",
+    "postinstall": "patch-package",
     "clean": "git clean -dfx lib dist modules node_modules",
     "build-common": "yarn workspace @ephox/bedrock-common build",
     "build-client": "yarn workspace @ephox/bedrock-client build",
@@ -43,6 +44,7 @@
     "lerna": "^3.18.3",
     "load-grunt-tasks": "^5.1.0",
     "mocha": "^8.2.0",
+    "patch-package": "^6.4.7",
     "typescript": "^4.0.3"
   },
   "engines": {

--- a/patches/sourcemapped-stacktrace+1.1.11.patch
+++ b/patches/sourcemapped-stacktrace+1.1.11.patch
@@ -1,0 +1,68 @@
+diff --git a/node_modules/sourcemapped-stacktrace/dist/sourcemapped-stacktrace.js b/node_modules/sourcemapped-stacktrace/dist/sourcemapped-stacktrace.js
+index afb408a..019361a 100644
+--- a/node_modules/sourcemapped-stacktrace/dist/sourcemapped-stacktrace.js
++++ b/node_modules/sourcemapped-stacktrace/dist/sourcemapped-stacktrace.js
+@@ -116,17 +116,14 @@ return /******/ (function(modules) { // webpackBootstrap
+ 	    }
+ 
+ 	    if (traceFormat === "chrome") {
+-	      regex = /^ +at.+\((.*):([0-9]+):([0-9]+)/;
++	      regex = /^ +at.+(https?:\/\/.*):([0-9]+):([0-9]+)/;
+ 	      expected_fields = 4;
+-	      // (skip first line containing exception message)
+-	      skip_lines = 1;
+ 	    } else {
+-	      regex = /@(.*):([0-9]+):([0-9]+)/;
++	      regex = /@(https?:\/\/.*):([0-9]+):([0-9]+)/;
+ 	      expected_fields = 4;
+-	      skip_lines = 0;
+ 	    }
+ 
+-	    lines = stack.split("\n").slice(skip_lines);
++	    lines = stack.split("\n");
+ 
+ 	    for (var i=0; i < lines.length; i++) {
+ 	      line = lines[i];
+@@ -304,19 +301,22 @@ return /******/ (function(modules) { // webpackBootstrap
+ 	  };
+ 
+ 	  function origNameChrome(origLine) {
+-	    var match = / +at +([^ ]*).*/.exec(origLine);
++	    var match = / +at +([^ ]*).*\(/.exec(origLine);
+ 	    return match && match[1];
+ 	  }
+ 
+ 	  function origNameFirefox(origLine) {
+-	    var match = /([^@]*)@.*/.exec(origLine);
++	    var match = /([^@]*?)(\/<)*@.*/.exec(origLine);
+ 	    return match && match[1];
+ 	  }
+ 
+ 	  var formatOriginalPosition = function(source, line, column, name) {
+ 	    // mimic chrome's format
+-	    return "    at " + (name ? name : "(unknown)") +
+-	      " (" + source + ":" + line + ":" + column + ")";
++			if (name) {
++				return "    at " + name + " (" + source + ":" + line + ":" + column + ")";
++			} else {
++				return "    at " + source + ":" + line + ":" + column;
++			}
+ 	  };
+ 
+ 	  // xmlhttprequest boilerplate
+diff --git a/node_modules/sourcemapped-stacktrace/index.d.ts b/node_modules/sourcemapped-stacktrace/index.d.ts
+index 1240936..a4fa66b 100644
+--- a/node_modules/sourcemapped-stacktrace/index.d.ts
++++ b/node_modules/sourcemapped-stacktrace/index.d.ts
+@@ -16,6 +16,9 @@ declare module 'sourcemapped-stacktrace' {
+      * @param done Callback invoked with the transformed stacktrace.
+      * @param opts Options object.
+      */
+-    export function mapStackTrace(stack: string | undefined, done: (mappedStack: string[]) => void, opts?: MapStackTraceOptions): void
+-
++    function mapStackTrace(stack: string | undefined, done: (mappedStack: string[]) => void, opts?: MapStackTraceOptions): void;
++    const _default: {
++        mapStackTrace: typeof mapStackTrace;
++    };
++    export default _default
+ }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,6 +1571,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -3108,7 +3113,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@^6.0.0:
+cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
   integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
@@ -4199,6 +4204,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 findup-sync@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
@@ -4349,6 +4361,15 @@ fs-extra@8.1.0, fs-extra@^8.1.0:
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   dependencies:
     graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  dependencies:
+    graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
@@ -5549,7 +5570,7 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is-wsl@^2.2.0:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -5764,6 +5785,13 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 lazystream@^1.0.0:
   version "1.0.0"
@@ -6919,6 +6947,14 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 opn@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
@@ -7208,6 +7244,25 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-package@^6.4.7:
+  version "6.4.7"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148"
+  integrity sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
 
 path-browserify@0.0.1:
   version "0.0.1"
@@ -8482,6 +8537,11 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+
 source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -8501,6 +8561,13 @@ sourcemap-codec@^1.4.4:
   version "1.4.6"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz#e30a74f0402bad09807640d39e971090a08ce1e9"
   integrity sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==
+
+sourcemapped-stacktrace@^1.1.11:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.11.tgz#e2dede7fc148599c52a4f883276e527f8452657d"
+  integrity sha512-O0pcWjJqzQFVsisPlPXuNawJHHg9N9UgpJ/aDmvi9+vnS3x1C0NhwkVFzzZ1VN0Xo+bekyweoqYvBw5ZBKiNnQ==
+  dependencies:
+    source-map "0.5.6"
 
 spdx-correct@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
This updates the runner to use the `sourcemapped-stacktrace` library to process the stack traces produced for failed tests and remap them using the generated source maps where they exist. This means that we'll get actual useful file names and line numbers for errors that occur instead of it just saying `tests.js`. As part of this, it does mean that we always generate a sourcemap with webpack now.

Note: Unfortunately, I did find some bugs/inconsistencies with the way the `sourcemapped-stacktrace` library worked, so it did need some patches. The patches I've done are safe in the context of bedrock (since we're always running via http), but probably aren't safe for general use so I haven't looked at contributing them back. Part of the issue was that the library only currently worked with named functions, not anon functions which produced a line such as `at http://localhost:8000/compiled/tests.js:14974:9`. It also caused the actual error message to get lost which isn't what we want.

New (IE 11):
```
Stack:
    at eq (webpack:///client/src/main/ts/api/LegacyAssert.ts:12:4)
    at test (webpack:///src/test/ts/client/SyncFailTest.ts:5:4)
    at Anonymous (webpack:///src/test/ts/client/SyncFailTest.ts:7:2)
    at Anonymous (http://localhost:8000/runner/runner.js:4521:17)
    at doResolve (http://localhost:8000/runner/runner.js:1078:11)
    at Promise (http://localhost:8000/runner/runner.js:989:9)
    at runExecFn (http://localhost:8000/runner/runner.js:4505:9)
    at run (http://localhost:8000/runner/runner.js:4549:13)
    at runWithCleanup (http://localhost:8000/runner/runner.js:4562:9)
    at Anonymous (http://localhost:8000/runner/runner.js:4589:17)
```

Old (IE 11):
```
Stack:
   at eq (http://localhost:8000/compiled/tests.js:14974:9)
   at test (http://localhost:8000/compiled/tests.js:16032:9)
   at Anonymous function (http://localhost:8000/compiled/tests.js:16034:5)
   at Anonymous function (http://localhost:8000/runner/runner.js:2071:17)
   at doResolve (http://localhost:8000/runner/runner.js:1078:11)
   at Promise (http://localhost:8000/runner/runner.js:989:9)
   at runExecFn (http://localhost:8000/runner/runner.js:2055:9)
   at run (http://localhost:8000/runner/runner.js:2099:13)
   at runWithCleanup (http://localhost:8000/runner/runner.js:2112:9)
   at Anonymous function (http://localhost:8000/runner/runner.js:2139:17)
```