### PR TITLE
TINY-7918: Improved the test execution speed on Chrome and Edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 11.5.0 - 2021-08-30
+
+### Improved
+- Improved test execution time on `Chrome` and `Edge` by using a faster mouse reset action.
+
 ## 11.4.0 - 2021-08-25
 
 ### Improved

--- a/modules/server/src/main/ts/bedrock/server/Apis.ts
+++ b/modules/server/src/main/ts/bedrock/server/Apis.ts
@@ -5,7 +5,6 @@ import * as Waiter from '../util/Waiter';
 import * as ClipboardEffects from './ClipboardEffects';
 import * as Controller from './Controller';
 import { DriverMaster } from './DriverMaster';
-import * as EffectUtils from './EffectUtils';
 import * as KeyEffects from './KeyEffects';
 import * as MouseEffects from './MouseEffects';
 import * as Routes from './Routes';
@@ -73,9 +72,13 @@ export const create = (master: DriverMaster | null, maybeDriver: Attempt<any, Br
       // TODO re-enable resetting the mouse on other browsers when mouseMove gets fixed on Firefox/IE
       const browserName = driver.capabilities.browserName;
       if (browserName === 'chrome' || browserName === 'msedge') {
-        return EffectUtils.getTarget(driver, {selector: '.bedrock-mouse-reset'}).then((target) => {
-          return target.moveTo();
-        });
+        // Reset the mouse position to the top left of the window
+        return driver.performActions([{
+          type: 'pointer',
+          id: 'finger1',
+          parameters: { pointerType: 'mouse' },
+          actions: [{ type: 'pointerMove', duration: 0, x: 0, y: 0 }]
+        }]);
       } else {
         return Promise.resolve();
       }

--- a/modules/server/src/resources/css/bedrock.css
+++ b/modules/server/src/resources/css/bedrock.css
@@ -11,15 +11,6 @@ body {
     margin: 0px;
 }
 
-.bedrock-mouse-reset {
-    position: fixed;
-    top: 0;
-    left: 0;
-    height: 0;
-    width: 0;
-    visibility: hidden;
-}
-
 .name {
     margin: 10px;
 }

--- a/modules/server/src/resources/html/bedrock-phantom.html
+++ b/modules/server/src/resources/html/bedrock-phantom.html
@@ -7,7 +7,6 @@
 </head>
 <body>
     <h1>Bedrock: Test Harness</h1>
-    <div class="bedrock-mouse-reset"></div>
     <script type="text/javascript" src="lib/jquery/jquery.min.js"></script>
     <script type="text/javascript" src="lib/core-js-bundle/minified.js"></script>
     <script type="text/javascript" src="runner/runner.js"></script>

--- a/modules/server/src/resources/html/bedrock.html
+++ b/modules/server/src/resources/html/bedrock.html
@@ -7,7 +7,6 @@
 </head>
 <body>
     <h1>Bedrock: Test Harness</h1>
-    <div class="bedrock-mouse-reset"></div>
     <script type="text/javascript" src="lib/jquery/jquery.min.js"></script>
     <script type="text/javascript" src="runner/runner.js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
This swaps the action used to reset the mouse position between tests on Chrome and Edge. For those that don't know the history, chromium browsers like to fire mouseover, etc... events for where the actual mouse, even when it's not moved, which can cause test flakes.

This version is ~3x faster than the old version (~10ms vs ~30ms), so while that's not much for a single test, when you have 5000+ tests as we do in TinyMCE, then it saves ~1&half; minutes.