### PR TITLE
TINY-7971: Added node environment definitions to webpack in JS mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- `process.env.NODE_ENV` and `process.env.NODE_DEBUG` are now defined when running in JS-only mode
+
 ## 12.0.0 - 2021-09-06
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Improved
-- `process.env.NODE_ENV` and `process.env.NODE_DEBUG` are now supported using a webpack `DefinePlugin`
+- `process.env.NODE_ENV` is now set to `development` using a webpack `DefinePlugin`
 
 ## 12.0.0 - 2021-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Improved
-- `process.env.NODE_ENV` and `process.env.NODE_DEBUG` are now defined when running in JS-only mode
+- `process.env.NODE_ENV` and `process.env.NODE_DEBUG` are now supported using a webpack `DefinePlugin`
 
 ## 12.0.0 - 2021-09-06
 

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -204,6 +204,12 @@ const getWebPackConfigJs = (scratchFile: string, dest: string, coverage: string[
         ] : []
       )
     },
+    plugins: [
+      new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify('development'),
+        'process.env.NODE_DEBUG': JSON.stringify(false),
+      })
+    ],
     output: {
       filename: path.basename(dest),
       path: path.resolve(path.dirname(dest))

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -153,6 +153,10 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
       // See https://github.com/TypeStrong/ts-loader#usage-with-webpack-watch
       new webpack.WatchIgnorePlugin({
         paths: [ /\.d\.ts$/ ]
+      }),
+      new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify('development'),
+        'process.env.NODE_DEBUG': JSON.stringify(false),
       })
     ],
 

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -155,8 +155,7 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
         paths: [ /\.d\.ts$/ ]
       }),
       new webpack.DefinePlugin({
-        'process.env.NODE_ENV': JSON.stringify('development'),
-        'process.env.NODE_DEBUG': JSON.stringify(false),
+        'process.env.NODE_ENV': JSON.stringify('development')
       })
     ],
 
@@ -210,8 +209,7 @@ const getWebPackConfigJs = (scratchFile: string, dest: string, coverage: string[
     },
     plugins: [
       new webpack.DefinePlugin({
-        'process.env.NODE_ENV': JSON.stringify('development'),
-        'process.env.NODE_DEBUG': JSON.stringify(false),
+        'process.env.NODE_ENV': JSON.stringify('development')
       })
     ],
     output: {


### PR DESCRIPTION
RTC runs a dual NodeJS + Bedrock test setup and some of the NodeJS-isms are too tightly integrated to remove easily.

This wasn't a problem with Webpack 4, it auto-bundles a lot of polyfills, but Webpack 5 stopped doing that.

I can manage `assert` and `util` by adding the webpack 4 versions as RTC dependencies but these polyfills still expect a `process` global. The only option I've found to mange code that uses `process.env` is a `DefinePlugin` (which does string replacement on bundled files).

I only did this to JS mode; I figure TypeScript code is less likely to need them.