### PR TITLE
TINY-7654: Use inline source maps for manual mode and ignore more changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 12.2.0 - 2021-11-18
+
+### Changed
+- Use inline source maps when running in manual mode.
+
+### Fixed
+- Webpack compilations were incorrectly triggered when the previous compilation finished and no changes had been made.
+
 ## 12.1.1 - 2021-09-20
 
 ### Fixed

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -157,7 +157,7 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
           /\.(js|ts)\.map$/,
           // Something seems to trigger that node module package.json files change when they
           // haven't, so lets just ignore them entirely
-          /node_modules\/.*package\.json$/
+          /node_modules\/.*\/package\.json$/
         ]
       }),
       new webpack.DefinePlugin({

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -77,7 +77,7 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
   return {
     stats: 'none',
     entry: scratchFile,
-    devtool: 'source-map',
+    devtool: manualMode ? 'inline-source-map' : 'source-map',
     mode: manualMode ? 'development' : 'none',
     target: [ 'web', 'es5' ],
 
@@ -150,9 +150,15 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
           }
         }
       }),
-      // See https://github.com/TypeStrong/ts-loader#usage-with-webpack-watch
       new webpack.WatchIgnorePlugin({
-        paths: [ /\.d\.ts$/ ]
+        paths: [
+          // Ignore generated files. See https://github.com/TypeStrong/ts-loader#usage-with-webpack-watch
+          /\.d\.ts$/,
+          /\.(js|ts)\.map$/,
+          // Something seems to trigger that node module package.json files change when they
+          // haven't, so lets just ignore them entirely
+          /node_modules\/.*package\.json$/
+        ]
       }),
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify('development')


### PR DESCRIPTION
This just makes some changes to improve inconveniences I found when getting this working in TinyMCE:
- Bedrock manual mode will now use inline source maps. They take about the same time to generate but ensures the source maps don't run into caching issues or similar when running in watch mode.
- Adds a few more paths to ignore to prevent webpack doing multiple compilations when not necessary.