### PR TITLE
TINY-8293: Revert swapping to use `promise-polyfill` directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 12.3.1 - 2021-12-08
+
+### Fixed
+- Rolled back to using the old `@ephox/wrap-promise-polyfill` due to `promise-polyfill` never attempting to use the native Promise implementation and was quite slow.
+
 ## 12.3.0 - 2021-12-07
 
 ### Changed

--- a/modules/runner/package.json
+++ b/modules/runner/package.json
@@ -11,14 +11,13 @@
   },
   "dependencies": {
     "@ephox/bedrock-common": "^12.0.0",
+    "@ephox/wrap-promise-polyfill": "^2.2.0",
     "jquery": "^3.4.1",
-    "promise-polyfill": "^8.0.0",
     "querystringify": "^2.1.1"
   },
   "devDependencies": {
     "@types/diff": "^5.0.0",
     "@types/jquery": "^3.5.3",
-    "@types/promise-polyfill": "^6.0.4",
     "@types/querystringify": "^2.0.0",
     "rollup": "^1.20.2",
     "rollup-plugin-commonjs": "^10.1.0",

--- a/modules/runner/src/main/ts/api/Main.ts
+++ b/modules/runner/src/main/ts/api/Main.ts
@@ -1,5 +1,5 @@
 import { Failure, Global } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import * as Globals from '../core/Globals';
 import * as TestLoader from '../core/TestLoader';
 import { UrlParams } from '../core/UrlParams';

--- a/modules/runner/src/main/ts/core/TestLoader.ts
+++ b/modules/runner/src/main/ts/core/TestLoader.ts
@@ -1,4 +1,4 @@
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import { ErrorCatcher } from '../errors/ErrorCatcher';
 
 export const load = (scriptUrl: string): Promise<void> =>

--- a/modules/runner/src/main/ts/core/Utils.ts
+++ b/modules/runner/src/main/ts/core/Utils.ts
@@ -1,5 +1,5 @@
 import { Suite, Test } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import sourceMappedStackTrace from 'sourcemapped-stacktrace';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/modules/runner/src/main/ts/reporter/Callbacks.ts
+++ b/modules/runner/src/main/ts/reporter/Callbacks.ts
@@ -1,5 +1,5 @@
 import { ErrorData, Global } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import { HarnessResponse } from '../core/ServerTypes';
 
 export interface TestErrorData {

--- a/modules/runner/src/main/ts/reporter/Reporter.ts
+++ b/modules/runner/src/main/ts/reporter/Reporter.ts
@@ -1,5 +1,5 @@
 import { LoggedError, Reporter as ErrorReporter } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import { Callbacks } from './Callbacks';
 import { UrlParams } from '../core/UrlParams';
 import { formatElapsedTime, mapStackTrace } from '../core/Utils';

--- a/modules/runner/src/main/ts/runner/Hooks.ts
+++ b/modules/runner/src/main/ts/runner/Hooks.ts
@@ -1,5 +1,5 @@
 import { Hook, HookType, RunnableState, Suite, Test } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import * as Context from '../core/Context';
 import { SkipError } from '../errors/Errors';
 import { runWithErrorCatcher, runWithTimeout } from './Run';

--- a/modules/runner/src/main/ts/runner/Run.ts
+++ b/modules/runner/src/main/ts/runner/Run.ts
@@ -1,5 +1,5 @@
 import { Context, ExecuteFn, Failure, Runnable, RunnableState, TestThrowable } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import { isInternalError, MultipleDone, SkipError } from '../errors/Errors';
 import { ErrorCatcher } from '../errors/ErrorCatcher';
 import { Timer } from './Timer';

--- a/modules/runner/src/main/ts/runner/Runner.ts
+++ b/modules/runner/src/main/ts/runner/Runner.ts
@@ -1,5 +1,5 @@
 import { Suite } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import { HarnessResponse } from '../core/ServerTypes';
 import { UrlParams } from '../core/UrlParams';
 import { noop } from '../core/Utils';

--- a/modules/runner/src/main/ts/runner/TestRun.ts
+++ b/modules/runner/src/main/ts/runner/TestRun.ts
@@ -1,5 +1,5 @@
 import { Failure, LoggedError, RunnableState, Suite, Test } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import * as Context from '../core/Context';
 import { InternalError, isInternalError, SkipError } from '../errors/Errors';
 import { Reporter, TestReporter } from '../reporter/Reporter';

--- a/modules/runner/src/main/ts/runner/Utils.ts
+++ b/modules/runner/src/main/ts/runner/Utils.ts
@@ -1,5 +1,5 @@
 import { Suite, Test } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 
 export const countTests = (suite: Suite): number =>
   suite.tests.length + suite.suites.reduce((acc, suite) => acc + countTests(suite), 0);

--- a/modules/runner/src/test/ts/reporter/ReporterTest.ts
+++ b/modules/runner/src/test/ts/reporter/ReporterTest.ts
@@ -1,5 +1,5 @@
 import { Failure, LoggedError } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import { assert } from 'chai';
 import * as fc from 'fast-check';
 import { beforeEach, describe, it } from 'mocha';

--- a/modules/runner/src/test/ts/runner/RunnerTestUtils.ts
+++ b/modules/runner/src/test/ts/runner/RunnerTestUtils.ts
@@ -1,5 +1,5 @@
 import { Hook, HookType, Suite } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import { createHook } from '../../../main/ts/core/Hook';
 import { Reporter, TestReporter } from '../../../main/ts/reporter/Reporter';
 import { RunState } from '../../../main/ts/runner/TestRun';

--- a/modules/runner/src/test/ts/runner/TestRunTest.ts
+++ b/modules/runner/src/test/ts/runner/TestRunTest.ts
@@ -1,5 +1,5 @@
 import { Context, HookType, RunnableState, Suite, Test } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import { assert } from 'chai';
 import * as fc from 'fast-check';
 import { beforeEach, describe, it } from 'mocha';

--- a/modules/runner/src/test/ts/runner/UtilsTest.ts
+++ b/modules/runner/src/test/ts/runner/UtilsTest.ts
@@ -1,5 +1,5 @@
 import { Suite } from '@ephox/bedrock-common';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 import { assert } from 'chai';
 import * as fc from 'fast-check';
 import { describe, it } from 'mocha';

--- a/modules/runner/tsconfig.json
+++ b/modules/runner/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "useUnknownInCatchVariables": false,
-    "allowSyntheticDefaultImports": true,
     "target": "es5",
     "module": "es2015",
     "lib": ["es2015", "dom"],

--- a/modules/sample/package.json
+++ b/modules/sample/package.json
@@ -16,11 +16,10 @@
   },
   "dependencies": {
     "@ephox/bedrock-client": "^12.0.0",
-    "promise-polyfill": "^8.2.1"
+    "@ephox/wrap-promise-polyfill": "^2.2.0"
   },
   "devDependencies": {
-    "@ephox/bedrock-server": "^12.3.0",
-    "@types/promise-polyfill": "^6.0.4"
+    "@ephox/bedrock-server": "^12.3.0"
   },
   "files": [],
   "private": true,

--- a/modules/sample/src/test/ts/client/fail/AsyncFailTest.ts
+++ b/modules/sample/src/test/ts/client/fail/AsyncFailTest.ts
@@ -1,5 +1,5 @@
 import { UnitTest } from '@ephox/bedrock-client';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 
 UnitTest.asyncTest('AsyncFail Test 1', (success, failure) => {
   setTimeout(() => {

--- a/modules/sample/src/test/ts/client/pass/AsyncPassTest.ts
+++ b/modules/sample/src/test/ts/client/pass/AsyncPassTest.ts
@@ -1,5 +1,5 @@
 import { UnitTest } from '@ephox/bedrock-client';
-import Promise from 'promise-polyfill';
+import Promise from '@ephox/wrap-promise-polyfill';
 
 UnitTest.asyncTest('AsyncPass Test 1', (success, _failure) => {
   new Promise<void>(function (resolve, _reject) {

--- a/modules/sample/tsconfig.json
+++ b/modules/sample/tsconfig.json
@@ -12,7 +12,6 @@
     "declaration": true,
     "outDir": "scratch/dist",
     "sourceMap": true,
-    "allowSyntheticDefaultImports": true,
     "types": []
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -240,6 +240,11 @@
   resolved "https://registry.yarnpkg.com/@ephox/dispute/-/dispute-1.0.4.tgz#9cc03a740548f2b3db43ac544050b7e3b36651dd"
   integrity sha512-PzklC1q7Flovi/pnxTFsY1pPKaEAm0whC+lFXM2Sh4Fc+lUt7A/UMRoV9bg9DyeTbD/mWEr/hvdyJp6hI14uKg==
 
+"@ephox/wrap-promise-polyfill@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@ephox/wrap-promise-polyfill/-/wrap-promise-polyfill-2.2.0.tgz#ea11e0a88320b5096dfed6249e169621c9853f7d"
+  integrity sha512-bTvZa0VEBPtCbcl05lYDjMre1WruTRXReCo8Yp2JrOnkf2PK8jgzBrOYPplbjgXvh6ToPqK2wiaeeBApYYgUSQ==
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -1443,11 +1448,6 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
-
-"@types/promise-polyfill@^6.0.4":
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/@types/promise-polyfill/-/promise-polyfill-6.0.4.tgz#c56670c70c601264c67191a85875fe2cf98a4cfd"
-  integrity sha512-GSCjjH6mDS8jgpT22rEOkZVqZcYj7i9AHJu4ntpvoohEpa0mLAKP/Kz3POMKqABaFsS4TyNHOeoyWpzycddcoQ==
 
 "@types/qs@*":
   version "6.9.7"
@@ -7524,11 +7524,6 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
-
-promise-polyfill@^8.0.0, promise-polyfill@^8.2.1:
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.1.tgz#1fa955b325bee4f6b8a4311e18148d4e5b46d254"
-  integrity sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg==
 
 promise-retry@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
This reverts commit 3312705b1fa8a7c2b3c8ec1110250aa36ec6119a.

Upon trying to upgrade to 12.3.0 Andy noticed things got a lot slower, which when we investigated we found the library never attempted to use the global and instead it was the contact wrapper that was using the global if available. As such for now we're just going to revert this and remove polyfilling altogether in the next major (we want to upgrade to the latest webpack-dev-server so will likely do it then).