### PR TITLE
TINY-8403: Fixed the server not always getting shutdown correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 12.3.2 - 2022-01-04
+
+### Fixed
+- The webdriver process would not be stopped in some cases when tests successfully completed.
+
 ## 12.3.1 - 2021-12-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - The webdriver process would not be stopped in some cases when tests successfully completed.
+- The server would not gracefully shutdown if an unexpected runner error occurred.
 
 ## 12.3.1 - 2021-12-08
 

--- a/modules/server/src/main/ts/bedrock/auto/Driver.ts
+++ b/modules/server/src/main/ts/bedrock/auto/Driver.ts
@@ -140,17 +140,20 @@ const focusBrowser = (browserName: string, settings: DriverSettings) => {
 
 const setupShutdown = (driver: WebdriverIO.Browser<'async'>, driverApi: DriverLoader.DriverAPI, shutdownDelay = 0): (immediate?: boolean) => Promise<void> => {
   const driverShutdown = async (immediate?: boolean) => {
-    if (immediate) {
-      driver.deleteSession();
-    } else {
-      await driver.pause(shutdownDelay);
-      await driver.deleteSession();
+    try {
+      if (immediate) {
+        driver.deleteSession();
+      } else {
+        await driver.pause(shutdownDelay);
+        await driver.deleteSession();
+      }
+    } finally {
+      driverApi.stop();
     }
   };
 
   Shutdown.registerShutdown((code, immediate) => {
     driverShutdown(immediate).finally(() => {
-      driverApi.stop();
       process.exit(code);
     });
   });

--- a/modules/server/src/main/ts/bedrock/core/Settings.ts
+++ b/modules/server/src/main/ts/bedrock/core/Settings.ts
@@ -4,7 +4,6 @@ export interface BedrockSettings {
   readonly basedir: string;
   readonly bundler: 'webpack' | 'rollup';
   readonly chunk: number;
-  readonly gruntDone?: (success: boolean) => void;
   readonly loglevel: 'simple' | 'advanced';
   readonly overallTimeout: number;
   readonly projectdir: string;
@@ -22,6 +21,7 @@ export interface BedrockSettings {
 export type BedrockManualSettings = BedrockSettings;
 
 export interface BedrockAutoSettings extends BedrockSettings {
+  readonly gruntDone?: (success: boolean) => void;
   readonly browser: string;
   readonly debuggingPort: number;
   readonly delayExit: boolean;


### PR DESCRIPTION
This was something I accidentally broke in 12.0.0 via https://github.com/tinymce/bedrock/pull/74. The problem is if a successful shutdown happens the `driverApi.stop()` function wasn't being called. That in turn meant the webdriver process would keep running forever depending on the shell/terminal being used. Additionally, if an unexpected runner error occurred it wasn't doing a graceful server shutdown and instead did a forced shutdown (since the `Reporter.writePollExit` call returns a rejected promise).