### PR TITLE
TINY-8189: Fixed the wrong timeout value being reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The webdriver process would not be stopped in some cases when tests successfully completed.
 - The server would not gracefully shutdown if an unexpected runner error occurred.
+- The wrong timeout value was reported when using the bedrock configured defaults.
 
 ## 12.3.1 - 2021-12-08
 

--- a/modules/runner/src/main/ts/runner/Run.ts
+++ b/modules/runner/src/main/ts/runner/Run.ts
@@ -94,9 +94,13 @@ const runWithCleanup = (runnable: Runnable, context: Context, cleanup: () => voi
   });
 
 export const runWithTimeout = (runnable: Runnable, context: Context, defaultTimeout: number): Promise<void> => {
+  // Update the runnable timeout to use the default timeout if required
+  if (runnable.timeout() === -1) {
+    runnable.timeout(defaultTimeout);
+  }
+
   // Run the execute function with a timeout if required
-  const timeout = runnable.timeout() === -1 ? defaultTimeout : runnable.timeout();
-  if (timeout <= 0) {
+  if (runnable.timeout() <= 0) {
     return run(runnable, context);
   } else {
     return new Promise((resolve, reject) => {
@@ -112,7 +116,7 @@ export const runWithTimeout = (runnable: Runnable, context: Context, defaultTime
       const unbind = runnable._onChange('timeout', timer.restart);
 
       // Start the timer
-      timer.start(timeout, () => {
+      timer.start(runnable.timeout(), () => {
         unbind();
         reject(Failure.prepFailure(new Error(`Test ran too long - timeout of ${runnable.timeout()}ms exceeded`)));
       });

--- a/modules/runner/src/main/ts/runner/Runner.ts
+++ b/modules/runner/src/main/ts/runner/Runner.ts
@@ -42,7 +42,7 @@ export const Runner = (rootSuite: Suite, params: UrlParams, callbacks: Callbacks
     const sum = reporter.summary();
     if (params.retry > 0) {
       params.retry = 0;
-      actions.updateHistory(params.offset, params.retry, sum.skipped);
+      actions.updateHistory(params.offset, sum.failed, sum.skipped, params.retry);
     }
   };
 


### PR DESCRIPTION
If a bedrock configured/default timeout occurred, then the wrong timeout value was reported in the error messages. This means you would have ended up with something like `Error: Test ran too long - timeout of -1ms exceeded`, so this ensures the correct timeout value is set for the runnable as that'll make sure if it's looked up in the test it has the right value as well.

Note: Also fixed a minor issue with the URL being shown incorrectly based on the state when a test is retried and then passes.