### PR TITLE
TINY-8165: Fixed cross frame uncaught errors not handled correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The webdriver process would not be stopped in some cases when tests successfully completed.
 - The server would not gracefully shutdown if an unexpected runner error occurred.
 - The wrong timeout value was reported when using the bedrock configured defaults.
+- Uncaught errors from other windows or frames wouldn't report correctly.
 
 ## 12.3.1 - 2021-12-08
 

--- a/modules/client/src/main/ts/core/Compare.ts
+++ b/modules/client/src/main/ts/core/Compare.ts
@@ -1,4 +1,4 @@
-import * as Type from './Type';
+import { Type } from '@ephox/bedrock-common';
 
 const Arr = {
   contains: (values: any[], value: any): boolean =>

--- a/modules/common/src/main/ts/api/Main.ts
+++ b/modules/common/src/main/ts/api/Main.ts
@@ -7,6 +7,7 @@ import * as TestError from './TestError';
 import { TestLabel } from './TestLabel';
 import * as TestLogs from './TestLogs';
 import { Context, ExecuteFn, Hook, HookType, Runnable, RunnableState, Suite, Test, TestGlobals } from './TestTypes';
+import * as Type from './Type';
 
 type TestThrowable = TestLabel | TestError.TestError;
 
@@ -20,6 +21,7 @@ export {
   TestLabel,
   TestLogs,
   TestThrowable,
+  Type,
 
   Context,
   ExecuteFn,

--- a/modules/common/src/main/ts/api/Type.ts
+++ b/modules/common/src/main/ts/api/Type.ts
@@ -1,4 +1,4 @@
-export const typeOf = function (x: any): string {
+export const typeOf = (x: any): string => {
   if (x === null) {
     return 'null';
   }
@@ -11,3 +11,11 @@ export const typeOf = function (x: any): string {
   }
   return t;
 };
+
+const isType = <T>(type: string) => (value: any): value is T => {
+  return typeOf(value) === type;
+};
+
+export const isString = isType<string>('string');
+// eslint-disable-next-line @typescript-eslint/ban-types
+export const isObject = isType<Object>('object');

--- a/modules/common/src/test/ts/api/TypeTest.ts
+++ b/modules/common/src/test/ts/api/TypeTest.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import * as fc from 'fast-check';
 import { describe, it } from 'mocha';
-import * as Type from '../../../main/ts/core/Type';
+import * as Type from '../../../main/ts/api/Type';
 
 describe('Type.typeOf', () => {
   it('is "string" for strings', () => {

--- a/modules/runner/src/test/ts/errors/ErrorCatcherTest.ts
+++ b/modules/runner/src/test/ts/errors/ErrorCatcherTest.ts
@@ -112,4 +112,29 @@ describe('ErrorCatcher', () => {
     assert.lengthOf(errors, 0);
     assert.isFalse(prevented, 'Event should not be prevented from running the default action');
   });
+
+  it('should handle cross frame errors', () => {
+    let prevented = false;
+    // Note: As this doesn't run in the browser we can't do a proper cross frame check so simulate an Error
+    // that doesn't use the current Error prototype
+    const frameError = {
+      message: 'frame message',
+      name: 'Error',
+      stack: 'Error\n    at <anonymous>:1:1'
+    };
+    const unhandledException = {
+      message: 'Unhandled error: frame message',
+      error: frameError,
+      preventDefault: () => {
+        prevented = true;
+      }
+    } as ErrorEvent;
+    fireEvent('error', unhandledException);
+
+    assert.lengthOf(errors, 1, 'Should contain one caught error');
+    const error = errors[0];
+    assert.equal(error.message, 'Unhandled error: frame message');
+    assert.equal(error.stack, frameError.stack);
+    assert.isTrue(prevented, 'Event should be prevented from running the default action');
+  });
 });


### PR DESCRIPTION
This fixes uncaught errors thrown within frames not getting their stack trace used due to the `instanceof Error` check failing. I've moved the `Type` module to bedrock common since it's now used by the client and runner (remember we can't use katamari).