### PR TITLE
TINY-8408: Ensure webdriver.io uses 127.0.0.1 when trying to connect to the webdriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improved
 - Upgrade to `webpack-dev-server` 4.x.
 
+### Fixed
+- Webdriver.io failed to connect to the webdriver instance on Node.js 17.
+
 ### Removed
 - Removed the deprecated `assert` client API.
 

--- a/modules/server/src/main/ts/bedrock/auto/Driver.ts
+++ b/modules/server/src/main/ts/bedrock/auto/Driver.ts
@@ -70,6 +70,7 @@ const addArguments = (capabilities: Record<string, any>, name: string, args: str
 const getOptions = (port: number, browserName: string, browserFamily: string, settings: DriverSettings): WebdriverIO.RemoteOptions => {
   const options = {
     path: '/',
+    host: '127.0.0.1',
     port,
     logLevel: 'silent' as const,
     capabilities: {

--- a/modules/server/src/main/ts/bedrock/auto/DriverLoader.ts
+++ b/modules/server/src/main/ts/bedrock/auto/DriverLoader.ts
@@ -98,7 +98,7 @@ export const loadDriver = (browserName: string, settings: DriverSettings): Drive
 };
 
 export const waitForAlive = (proc: ChildProcess, port: number, timeout = 30000): Promise<void> => {
-  const url = 'http://localhost:' + port + '/status';
+  const url = 'http://127.0.0.1:' + port + '/status';
   const start = Date.now();
   return new Promise<void>((resolve, reject) => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
Not all webdrivers support ipv6 and Node.js 17 will now attempt to use it when resolving hostnames, so this just forces it to use `127.0.0.1` which all webdrivers support.