### PR TITLE
TINY-8299: Removed TypeScript compiler overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed the deprecated `assert` client API.
+- Removed the TypeScript compiler `declarationMap` and `rootDir` overrides.
 
 ## 12.3.2 - 2022-01-04
 

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -69,11 +69,6 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
-  const compilerOverrides = {
-    rootDir: '.',
-    declarationMap: false
-  };
-
   return {
     stats: 'none',
     entry: scratchFile,
@@ -117,8 +112,7 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
                 colors: manualMode,
                 configFile: tsConfigFile,
                 transpileOnly: true,
-                projectReferences: true,
-                compilerOptions: compilerOverrides
+                projectReferences: true
               }
             }
           ]
@@ -144,10 +138,7 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
         typescript: {
           memoryLimit: manualMode ? 4096 : 2048,
           configFile: tsConfigFile,
-          build: true,
-          configOverwrite: {
-            compilerOptions: compilerOverrides
-          }
+          build: true
         }
       }),
       new webpack.WatchIgnorePlugin({


### PR DESCRIPTION
I've removed this as we found while investigating performance issues that these a) don't appear to be needed anymore and b) are causing things to have to be recompiled, especially with incremental builds.