### PR TITLE
TINY-8414: Fixed an issue where the webpack-dev-server overlay would show for re-exported types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 13.0.1 - 2022-02-01
+
+### Fixed
+- The `webpack-dev-server` warning overlay would incorrectly show for re-exported types.
+
 ## 13.0.0 - 2022-01-10
 
 ### Added

--- a/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
+++ b/modules/server/src/main/ts/bedrock/compiler/Webpack.ts
@@ -80,6 +80,12 @@ const getWebPackConfigTs = (tsConfigFile: string, scratchFile: string, dest: str
       usedExports: !manualMode
     },
 
+    ignoreWarnings: [
+      // suppress type re-export warnings caused by `transpileOnly: true`
+      // See https://github.com/TypeStrong/ts-loader#transpileonly
+      /export .* was not found in/
+    ],
+
     resolve: {
       extensions: [ '.ts', '.tsx', '.js', '.mjs' ],
       plugins: [
@@ -328,10 +334,7 @@ export const devserver = async (settings: WebpackServeSettings): Promise<Serve.S
           errorsCount: true,
           warnings: true,
           warningsCount: true,
-          logging: 'warn',
-
-          // suppress type re-export warnings caused by `transpileOnly: true`
-          warningsFilter: /export .* was not found in/
+          logging: 'warn'
         }
       },
       // Static content is handled via the bedrock middleware below


### PR DESCRIPTION
This was done as the `stats.warningsFilter` is now deprecated and doesn't seem to be respected for the overlay, so I've moved the filter to the appropriate place for Webpack 5, combined with Webpack Dev Server 4.