### PR TITLE
TINY-8502: Improve when mouse position resets occur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Improved
+- The mouse position reset logic now only runs when required, instead of for every test.
+
 ## 13.0.1 - 2022-02-01
 
 ### Fixed

--- a/modules/runner/src/main/ts/reporter/Callbacks.ts
+++ b/modules/runner/src/main/ts/reporter/Callbacks.ts
@@ -10,6 +10,7 @@ export interface TestErrorData {
 export interface Callbacks {
   readonly loadHarness: () => Promise<HarnessResponse>
   readonly sendKeepAlive: (session: string) => Promise<void>;
+  readonly sendInit: (session: string) => Promise<void>;
   readonly sendTestStart: (session: string, totalTests: number, file: string, name: string) => Promise<void>;
   readonly sendTestResult: (session: string, file: string, name: string, passed: boolean, time: string, error: TestErrorData | null, skipped: string | null) => Promise<void>;
   readonly sendDone: (session: string, error?: string) => Promise<void>;
@@ -49,6 +50,12 @@ const getJson = <T>(url: string): Promise<T> => {
 export const Callbacks = (): Callbacks => {
   const loadHarness = (): Promise<HarnessResponse> => {
     return getJson('harness');
+  };
+
+  const sendInit = (session: string): Promise<void> => {
+    return sendJson('/tests/init', {
+      session,
+    });
   };
 
   const sendKeepAlive = (session: string): Promise<void> => {
@@ -91,6 +98,7 @@ export const Callbacks = (): Callbacks => {
 
   return {
     loadHarness,
+    sendInit,
     sendKeepAlive,
     sendTestStart,
     sendTestResult,

--- a/modules/runner/src/main/ts/runner/Runner.ts
+++ b/modules/runner/src/main/ts/runner/Runner.ts
@@ -74,7 +74,7 @@ export const Runner = (rootSuite: Suite, params: UrlParams, callbacks: Callbacks
       });
     }, KEEP_ALIVE_INTERVAL);
 
-    return callbacks.loadHarness();
+    return callbacks.sendInit(params.session).then(() => callbacks.loadHarness());
   };
 
   const run = (chunk: number, retries: number, timeout: number, stopOnFailure: boolean): Promise<void> => {

--- a/modules/runner/src/test/ts/reporter/ReporterTest.ts
+++ b/modules/runner/src/test/ts/reporter/ReporterTest.ts
@@ -50,6 +50,7 @@ describe('Reporter.test', () => {
   const callbacks: Callbacks = {
     loadHarness: () => Promise.resolve({ retries: 0, chunk: 100, stopOnFailure: true, mode: 'manual', timeout: 10000 }),
     sendKeepAlive: () => Promise.resolve(),
+    sendInit: () => Promise.resolve(),
     sendTestStart: (session, totalTests, file, name) => {
       startTestData.push({ session, totalTests, file, name });
       return Promise.resolve();

--- a/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
+++ b/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
@@ -279,7 +279,7 @@ export const skipResetMousePosition: ClOption = {
   name: 'skipResetMousePosition',
   type: Boolean,
   defaultValue: false,
-  description: 'Prevent bedrock from resetting the mouse position to the top left corner of the screen between each test',
+  description: 'Prevent bedrock from resetting the mouse position to the top left corner of the screen between tests',
   validate: Extraction.any,
   uncommon: true
 };


### PR DESCRIPTION
This improves when the mouse reset position logic happens for bedrock auto mode, so that it only does it when required instead of for every single test. This should help to speed up our Chrome and Edge tests, especially on the M1 nodes (TinyMCE went from 9mins down to about 4mins in my testing).

The idea behind this change is to make it so that the mouse position only resets at the start of the runner init sequence (e.g. on first run and then on page reloads for test failures) and also when a previous test moves the mouse around.