### PR TITLE
TINY-8944: Fixed the key effects leaving modifier keys active on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 13.2.2 - 2022-07-29
+
+### Fixed
+- Modifier keys would not be released on all browsers when using a key effect.
+
 ## 13.2.1 - 2022-05-17
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Modifier keys would not be released on all browsers when using a key effect.
+- The error message was lost when running on phantomjs.
 
 ## 13.2.1 - 2022-05-17
 

--- a/modules/runner/src/main/ts/core/Utils.ts
+++ b/modules/runner/src/main/ts/core/Utils.ts
@@ -55,3 +55,11 @@ export const mapStackTrace = (stack: string | undefined): Promise<string> => new
     resolve('');
   }
 });
+
+export const setStack = (error: Error, stack: string | undefined): void => {
+  try {
+    error.stack = stack;
+  } catch (err) {
+    // Do nothing
+  }
+};

--- a/modules/runner/src/main/ts/errors/ErrorCatcher.ts
+++ b/modules/runner/src/main/ts/errors/ErrorCatcher.ts
@@ -1,4 +1,5 @@
 import { Global, Type } from '@ephox/bedrock-common';
+import { setStack } from '../core/Utils';
 import { isInternalError } from './Errors';
 
 type ErrorHandler = (error: Error) => void
@@ -35,7 +36,7 @@ export const ErrorCatcher = (): ErrorCatcher => {
   const onUnhandledRejection = createHandler((e: PromiseRejectionEvent) => {
     if (isError(e.reason)) {
       const error = new Error(`Unhandled promise rejection: ${e.reason.message}`);
-      error.stack = e.reason.stack;
+      setStack(error, e.reason.stack);
       return error;
     } else {
       return new Error(`Unhandled promise rejection: ${e.reason}`);
@@ -48,7 +49,7 @@ export const ErrorCatcher = (): ErrorCatcher => {
         return e.error;
       } else {
         const error = new Error(e.message);
-        error.stack = e.error.stack;
+        setStack(error, e.error.stack);
         return error;
       }
     } else {

--- a/modules/runner/src/main/ts/reporter/Reporter.ts
+++ b/modules/runner/src/main/ts/reporter/Reporter.ts
@@ -2,7 +2,7 @@ import { LoggedError, Reporter as ErrorReporter } from '@ephox/bedrock-common';
 import Promise from '@ephox/wrap-promise-polyfill';
 import { Callbacks } from './Callbacks';
 import { UrlParams } from '../core/UrlParams';
-import { formatElapsedTime, mapStackTrace } from '../core/Utils';
+import { formatElapsedTime, mapStackTrace, setStack } from '../core/Utils';
 
 type LoggedError = LoggedError.LoggedError;
 
@@ -34,7 +34,7 @@ const elapsed = (since: Date): string => formatElapsedTime(since, new Date());
 
 const mapError = (e: LoggedError) => mapStackTrace(e.stack).then((mappedStack) => {
   const originalStack = e.stack;
-  e.stack = mappedStack;
+  setStack(e, mappedStack);
 
   // Logs may have the stack trace included as well, so ensure we replace that as well
   if (e.logs !== undefined && e.logs.length > 0 && originalStack !== undefined) {

--- a/modules/sample/src/test/ts/client/ClipboardTest.ts
+++ b/modules/sample/src/test/ts/client/ClipboardTest.ts
@@ -1,36 +1,14 @@
 import { UnitTest } from '@ephox/bedrock-client';
 
+import { post, sendKeyCombo } from '../utils/Utils';
+
 UnitTest.asynctest('Clipboard Test', (success, failure) => {
-
-  if (window.fetch === undefined) return failure('This sample only runs on Chrome');
-
-  const importClipboard = function (fileName) {
-    return fetch('/clipboard', {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        import: fileName
-      })
-    });
+  const importClipboard = function (fileName: string) {
+    return post('/clipboard', { import: fileName });
   };
 
   const pasteInto = function (elm) {
-    return fetch('/keys', {
-      method: 'POST',
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        keys: [
-          {combo: {ctrlKey: true, key: 'v'}}
-        ],
-        selector: '#' + elm.id
-      })
-    });
+    return sendKeyCombo('#' + elm.id, 'v', { ctrlKey: true });
   };
 
   const assert = function () {
@@ -55,5 +33,6 @@ UnitTest.asynctest('Clipboard Test', (success, failure) => {
     })
     .catch(function (ex) {
       console.log('parsing failed', ex);
+      failure(ex);
     });
 });

--- a/modules/sample/src/test/ts/client/pass/EffectsTest.ts
+++ b/modules/sample/src/test/ts/client/pass/EffectsTest.ts
@@ -1,0 +1,49 @@
+import { after, Assert, before, beforeEach, context, describe, it } from '@ephox/bedrock-client';
+
+import { sendText, sendKeyCombo } from '../../utils/Utils';
+
+describe('Effects', () => {
+  const isPhantom = navigator.userAgent.indexOf('PhantomJS') > -1;
+  const isMac = navigator.platform.indexOf('Mac') > -1;
+
+  context('keys', () => {
+    const ctrlKeyModifier = isMac && !isPhantom ? { metaKey: true } : { ctrlKey: true };
+    let textarea: HTMLTextAreaElement;
+
+    before(() => {
+      textarea = document.createElement('textarea');
+      document.body.appendChild(textarea);
+    });
+
+    after(() => {
+      if (textarea) {
+        document.body.removeChild(textarea);
+      }
+    });
+
+    beforeEach(() => {
+      textarea.value = '';
+    });
+
+    it('should cut and paste using keyboard shortcuts', async function () {
+      // Cut/Copy doesn't work on phantomjs
+      if (isPhantom) {
+        this.skip();
+      }
+
+      textarea.value = 'hello world';
+      textarea.select();
+
+      await sendKeyCombo('textarea', 'x', ctrlKeyModifier);
+      Assert.eq('Textarea value after cutting', '', textarea.value);
+
+      await sendKeyCombo('textarea', 'v', ctrlKeyModifier);
+      Assert.eq('Textarea value after pasting', 'hello world', textarea.value);
+    });
+
+    it('should type text', async () => {
+      await sendText('textarea', 'hello world!');
+      Assert.eq('Textarea value after typing', 'hello world!', textarea.value);
+    });
+  });
+});

--- a/modules/sample/src/test/ts/utils/Utils.ts
+++ b/modules/sample/src/test/ts/utils/Utils.ts
@@ -1,0 +1,42 @@
+import Promise from '@ephox/wrap-promise-polyfill';
+
+const post = (url: string, data: Record<string, any>): Promise<void> => {
+  return new Promise((onSuccess, onFailure) => {
+    const request = new XMLHttpRequest();
+    request.onreadystatechange = function () {
+      if (request.readyState === 4) {
+        if (request.status == 200) {
+          onSuccess();
+        } else {
+          onFailure();
+        }
+      }
+    };
+
+    request.onerror = function (err) {
+      debugger;
+      console.error(err);
+      onFailure();
+    };
+
+    request.open('POST', url);
+    request.setRequestHeader('Content-Type', 'application/json');
+    request.send(JSON.stringify(data));
+  });
+};
+
+const sendText = (selector: string, text: string): Promise<void> =>
+  post('/keys', { selector, keys: [ { text } ] });
+
+const sendKeyCombo = (selector: string, key: string, modifiers: Record<string, boolean>): Promise<void> =>
+  post('/keys', { selector, keys: [ { combo: { ...modifiers, key } } ] });
+
+const sendMouse = (selector: string, type: 'move' | 'click' | 'down' | 'up'): Promise<void> =>
+  post('/mouse', { selector, type });
+
+export {
+  post,
+  sendKeyCombo,
+  sendText,
+  sendMouse
+};

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -62,7 +62,8 @@
     "@types/fresh": "^0.5.0",
     "@types/jquery": "^3.5.11",
     "@types/mime-types": "^2.1.1",
-    "@types/mkdirp": "^1.0.1"
+    "@types/mkdirp": "^1.0.1",
+    "@wdio/types": "^7.20.7"
   },
   "peerDependencies": {
     "typescript": ">=3.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,15 +1469,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.3.tgz#bbeb55fbc73f28ea6de601fbfa4613f58d785323"
   integrity sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==
 
-"@types/node@*":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
-  integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
-
-"@types/node@>= 8", "@types/node@^17.0.4":
-  version "17.0.34"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.34.tgz#3b0b6a50ff797280b8d000c6281d229f9c538cef"
-  integrity sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==
+"@types/node@*", "@types/node@>= 8", "@types/node@^18.0.0":
+  version "18.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.2.tgz#ffc5f0f099d27887c8d9067b54e55090fcd54126"
+  integrity sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1679,15 +1674,16 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@wdio/config@7.19.5":
-  version "7.19.5"
-  resolved "https://registry.yarnpkg.com/@wdio/config/-/config-7.19.5.tgz#aa8158d648e1ffb28a7e53474d5ce171066e82f7"
-  integrity sha512-GyG0SSUjw9RyDgEwculgwiWyQ0eEeFAgaKTAa4RHC6ZgHHTgfyxzkWqBmNLzHfiB6GSR2DyZDcDsPT7ZAHkiEg==
+"@wdio/config@7.20.8":
+  version "7.20.8"
+  resolved "https://registry.yarnpkg.com/@wdio/config/-/config-7.20.8.tgz#0cec7a822e7bdbb63169b6da38d56bf6030b520c"
+  integrity sha512-MPB88Njua6T2PYkkpUdLmPn73XWPBbew46twQLNuQ99Q5pdRrsiPFgPT4aO9pPfIMMGpQQ8QCy8s0xpCuTEwBQ==
   dependencies:
     "@wdio/logger" "7.19.0"
-    "@wdio/types" "7.19.5"
+    "@wdio/types" "7.20.7"
+    "@wdio/utils" "7.20.7"
     deepmerge "^4.0.0"
-    glob "^7.1.2"
+    glob "^8.0.3"
 
 "@wdio/logger@7.19.0":
   version "7.19.0"
@@ -1699,33 +1695,33 @@
     loglevel-plugin-prefix "^0.8.4"
     strip-ansi "^6.0.0"
 
-"@wdio/protocols@7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@wdio/protocols/-/protocols-7.19.0.tgz#cd753752c64b9c1dd7ace05398c1d11c46af41ab"
-  integrity sha512-ji74rQag6v+INSNd0J8eAh2rpH5vOXgeiP5Qr32K6PWU6HzYWuAFH2x4srXsH0JawHCdTK2OQAOYrLmMb44hug==
+"@wdio/protocols@7.20.6":
+  version "7.20.6"
+  resolved "https://registry.yarnpkg.com/@wdio/protocols/-/protocols-7.20.6.tgz#e17207fe9b6783535f05c221701d64fa8dc069c0"
+  integrity sha512-+G7zAw7MsjohFU+xVJO9unc4eUuTX3UdVT3mQGDHQLuSGNGVL5QrtgEGYx8x32OMkFX4zs6ncObVAf0kR6H4Mg==
 
-"@wdio/repl@7.19.7":
-  version "7.19.7"
-  resolved "https://registry.yarnpkg.com/@wdio/repl/-/repl-7.19.7.tgz#bfcc1128785bc747e775c6baa280782f7e064eb7"
-  integrity sha512-6lgzZxSU2yV0YLb4byBASeC42y5rAZk7mOQ41fHTXyC9CfRJubwe47M9KJyAoOrHG2wpwUX92RLTpDrAVDV6Fg==
+"@wdio/repl@7.20.7":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@wdio/repl/-/repl-7.20.7.tgz#cde51604f1c4bc28cb2e8c298604993f4a939a49"
+  integrity sha512-9FXLyRWX7arYScEf9wFqkDuttVAPMJ91WA3C0FDf3vqbTxv1/4V5etkds/b7nH6SHq1FHdlcN4LCZ7lIfbu72Q==
   dependencies:
-    "@wdio/utils" "7.19.7"
+    "@wdio/utils" "7.20.7"
 
-"@wdio/types@7.19.5":
-  version "7.19.5"
-  resolved "https://registry.yarnpkg.com/@wdio/types/-/types-7.19.5.tgz#e05790f61dfab54ee6683ac799cb5f96615d1d0f"
-  integrity sha512-S1lC0pmtEO7NVH/2nM1c7NHbkgxLZH3VVG/z6ym3Bbxdtcqi2LMsEvvawMAU/fmhyiIkMsGZCO8vxG9cRw4z4A==
+"@wdio/types@7.20.7", "@wdio/types@^7.20.7":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@wdio/types/-/types-7.20.7.tgz#77ec8d4060f0eb4eb9455586c10ca8347f85986e"
+  integrity sha512-MXz/J5GYswCaa+pyWEVpJoafnbqZr0eJf4p/Z9KsSB5xPWh5Co/1Y8gNLlR1msjV8jKhoWCh55uoBZFU//7G1A==
   dependencies:
-    "@types/node" "^17.0.4"
+    "@types/node" "^18.0.0"
     got "^11.8.1"
 
-"@wdio/utils@7.19.7":
-  version "7.19.7"
-  resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-7.19.7.tgz#b1dd86a12a08ba4f445a70c9859e30cff6eb522f"
-  integrity sha512-i/fBnEmEGDQ8Sr8H8p9UZ0kUPjSQhoJE2EullSyX+YgyZDtO3JO0M0jiRpbCFr0M+7fi17g+YOzQWmCSRGhPJA==
+"@wdio/utils@7.20.7":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-7.20.7.tgz#746f1bce95e5cf3a101ab297764a2cb673b3d878"
+  integrity sha512-9KnvQ3J6+Jb/1Hzqhpf/QMr3t0rWG76A/gpw80ZIzUoMZzdquqSkDSlF1sOW2+GF2W3K1VsSB7ZcPelpadAsvw==
   dependencies:
     "@wdio/logger" "7.19.0"
-    "@wdio/types" "7.19.5"
+    "@wdio/types" "7.20.7"
     p-iteration "^1.1.8"
 
 "@webassemblyjs/ast@1.11.1":
@@ -3445,23 +3441,23 @@ devtools-protocol@0.0.981744:
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.981744.tgz#9960da0370284577d46c28979a0b32651022bacf"
   integrity sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==
 
-devtools-protocol@^0.0.998712:
-  version "0.0.998712"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.998712.tgz#35788d4e9e91c55288330f3ae8cc4584b21e07bc"
-  integrity sha512-KCl+wJ9RsnDyGSsW7nbkgLFYxcKxZ7nzr6/r/hMOjkS02q2x1p8PbUenzKRMfL0jALhYxkCHrYnPnV3GHVD9EQ==
+devtools-protocol@^0.0.1027518:
+  version "0.0.1027518"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1027518.tgz#5434d0cdcc89b085041ebded1287c3332998f5cd"
+  integrity sha512-qujzopk6PjSKlce9G12oAyLvCs2K2Qgp7DMBxkAhR2rmr3Q+m1ltWHRa0lDPO0I38/J0hC6fZhTJm2el87mIdA==
 
-devtools@7.19.7:
-  version "7.19.7"
-  resolved "https://registry.yarnpkg.com/devtools/-/devtools-7.19.7.tgz#b9091006f698303021dfb6593c35fe2792ca2601"
-  integrity sha512-XkIuojwTD0LeCzEeoTozKfAYWZUAw5Sj6CNPUuift3eDD9wnY2AcKLmFw8e9ihVUevJriyV8tMNbDsl97HSYWg==
+devtools@7.20.8:
+  version "7.20.8"
+  resolved "https://registry.yarnpkg.com/devtools/-/devtools-7.20.8.tgz#b03a63a96d56e87fe978e8f84c2fddcfe4c42329"
+  integrity sha512-EsJSICiJiY7hjXN18Ys1q5Hg3pSaTY5I7sBrwpVycYddm41UYGGTCcQOLEDJZZb0wxwgj2gyW0/i2vh7UYU/sw==
   dependencies:
-    "@types/node" "^17.0.4"
+    "@types/node" "^18.0.0"
     "@types/ua-parser-js" "^0.7.33"
-    "@wdio/config" "7.19.5"
+    "@wdio/config" "7.20.8"
     "@wdio/logger" "7.19.0"
-    "@wdio/protocols" "7.19.0"
-    "@wdio/types" "7.19.5"
-    "@wdio/utils" "7.19.7"
+    "@wdio/protocols" "7.20.6"
+    "@wdio/types" "7.20.7"
+    "@wdio/utils" "7.20.7"
     chrome-launcher "^0.15.0"
     edge-paths "^2.1.0"
     puppeteer-core "^13.1.3"
@@ -4620,7 +4616,7 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -4631,6 +4627,17 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
+  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
 
 glob@~5.0.0:
   version "5.0.15"
@@ -5789,7 +5796,7 @@ klaw-sync@^6.0.0:
   dependencies:
     graceful-fs "^4.1.11"
 
-ky@^0.30.0:
+ky@0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/ky/-/ky-0.30.0.tgz#a3d293e4f6c4604a9a4694eceb6ce30e73d27d64"
   integrity sha512-X/u76z4JtDVq10u1JA5UQfatPxgPaVDMYTrgHyiTpGN2z4TMEJkIHsoSBBSg9SWZEIXTKsi9kHgiQ9o3Y/4yog==
@@ -6367,7 +6374,7 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.0:
+minimatch@^5.0.0, minimatch@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
   integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
@@ -9315,40 +9322,40 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
-webdriver@7.19.7:
-  version "7.19.7"
-  resolved "https://registry.yarnpkg.com/webdriver/-/webdriver-7.19.7.tgz#be2ba4052d9fad9cfdc88024949a55cb2f28168f"
-  integrity sha512-3gygDpwaCMZlUhh7Wv1SbjTvfdLGbPqRQ3poZ7lKvsVAAmciLziJDeR8LrNTyS9R418MgNbBdWOQrHGS+gp0ZQ==
+webdriver@7.20.8:
+  version "7.20.8"
+  resolved "https://registry.yarnpkg.com/webdriver/-/webdriver-7.20.8.tgz#3b9f38439a8abb5a51fac59d42581a22d9e8824f"
+  integrity sha512-XMOy6K/jHR7GkU8BMzl5jmzoYf9jWoEDrieG16EobFFV5m1tC5ZoTPIx+pLAfleMKJdbjj9Lf5QpoY23M1BSuw==
   dependencies:
-    "@types/node" "^17.0.4"
-    "@wdio/config" "7.19.5"
+    "@types/node" "^18.0.0"
+    "@wdio/config" "7.20.8"
     "@wdio/logger" "7.19.0"
-    "@wdio/protocols" "7.19.0"
-    "@wdio/types" "7.19.5"
-    "@wdio/utils" "7.19.7"
+    "@wdio/protocols" "7.20.6"
+    "@wdio/types" "7.20.7"
+    "@wdio/utils" "7.20.7"
     got "^11.0.2"
-    ky "^0.30.0"
+    ky "0.30.0"
     lodash.merge "^4.6.1"
 
 webdriverio@^7.0.0:
-  version "7.19.7"
-  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-7.19.7.tgz#781d43cf4db272537cd5422649145f93225b6aa2"
-  integrity sha512-GaekRmFN3wokW3VN08hFjTJ3GagJxuKR6AV8kVvlxxMye9nfU3TQPzsrqGrue8uWYvyZ3x0SVkUluwtImZNzPA==
+  version "7.20.8"
+  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-7.20.8.tgz#96f24371b40b5a12feb7031516e166ae864d16e9"
+  integrity sha512-1FN1LzMmB2HAtLr817MeQ4XF31r539CiYU+/l78eK+IwQq0rGfj6lY2yqk1oGtEwvH3W39mvLjMirz0VdY+Ilg==
   dependencies:
     "@types/aria-query" "^5.0.0"
-    "@types/node" "^17.0.4"
-    "@wdio/config" "7.19.5"
+    "@types/node" "^18.0.0"
+    "@wdio/config" "7.20.8"
     "@wdio/logger" "7.19.0"
-    "@wdio/protocols" "7.19.0"
-    "@wdio/repl" "7.19.7"
-    "@wdio/types" "7.19.5"
-    "@wdio/utils" "7.19.7"
+    "@wdio/protocols" "7.20.6"
+    "@wdio/repl" "7.20.7"
+    "@wdio/types" "7.20.7"
+    "@wdio/utils" "7.20.7"
     archiver "^5.0.0"
     aria-query "^5.0.0"
     css-shorthand-properties "^1.1.1"
     css-value "^0.0.1"
-    devtools "7.19.7"
-    devtools-protocol "^0.0.998712"
+    devtools "7.20.8"
+    devtools-protocol "^0.0.1027518"
     fs-extra "^10.0.0"
     grapheme-splitter "^1.0.2"
     lodash.clonedeep "^4.5.0"
@@ -9361,7 +9368,7 @@ webdriverio@^7.0.0:
     resq "^1.9.1"
     rgb2hex "0.2.5"
     serialize-error "^8.0.0"
-    webdriver "7.19.7"
+    webdriver "7.20.8"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Related Ticket: TINY-8944

Description of Changes:

Changed how the key effects logic works when using a combo key effect so that it uses the webdriver.io `keys` API instead to ensure modifier keys are released properly. Note that this can't be used at all times, as we need to use `elementSendKeys` when actually typing text otherwise it won't show.

I also fixed an issue I found when trying to debug whereby a `TypeError: Attempted to assign to readonly property` would get thrown instead on PhantomJS due to `stack` being a readonly property. So we just skip setting the stack in that case, even if it means the stack is no longer useful as it's only an issue on PhantomJS.

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] Tests have been added (if applicable)

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
