### PR TITLE
TINY-8703: Improved the headless debugging port handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 13.2.2 - 2022-07-29
+## 13.3.0 - 2022-08-01
+
+### Improved
+- Headless browsers will now detect an available debugging port instead of always using port 9000.
+- Allow `edge` to be used as an alias for `MicrosoftEdge`.
 
 ### Fixed
+- Chrome headless tests no longer hang indefinitely if something else is running on port 9000.
 - Modifier keys would not be released on all browsers when using a key effect.
 - The error message was lost when running on phantomjs.
 

--- a/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
+++ b/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
@@ -139,7 +139,6 @@ export const debuggingPort: ClOption = {
   type: Number,
   description: 'The port for remote debugging (used for phantom and headless browsers)',
   validate: Extraction.any,
-  defaultValue: 9000,
   uncommon: true
 };
 
@@ -265,11 +264,11 @@ export const useSandboxForHeadless: ClOption = {
 };
 
 /*
- * In several situations, we need to pass through specific options to the 
- * browser's being launched. For example, Chrome Headless uses quite a lot 
- * of /dev/shm which can be a problem when running in docker containers, 
- * as the default of docker containers is just 64MB. The solution that 
- * Google tends to offer is to disable /dev/shm usage altogether through a 
+ * In several situations, we need to pass through specific options to the
+ * browser's being launched. For example, Chrome Headless uses quite a lot
+ * of /dev/shm which can be a problem when running in docker containers,
+ * as the default of docker containers is just 64MB. The solution that
+ * Google tends to offer is to disable /dev/shm usage altogether through a
  * chrome flag (https://developers.google.com/web/tools/puppeteer/troubleshooting#tips)
  */
 export const extraBrowserCapabilities: ClOption = {

--- a/modules/server/src/main/ts/bedrock/core/Settings.ts
+++ b/modules/server/src/main/ts/bedrock/core/Settings.ts
@@ -24,7 +24,7 @@ export type BedrockManualSettings = BedrockSettings;
 export interface BedrockAutoSettings extends BedrockSettings {
   readonly gruntDone?: (success: boolean) => void;
   readonly browser: string;
-  readonly debuggingPort: number;
+  readonly debuggingPort?: number;
   readonly delayExit: boolean;
   readonly name: string;
   readonly output: string;

--- a/modules/server/src/test/ts/ClisTest.ts
+++ b/modules/server/src/test/ts/ClisTest.ts
@@ -44,7 +44,6 @@ describe('Clis.forAuto', () => {
       testfiles: [
         'src/test/resources/test.file1'
       ],
-      debuggingPort: 9000,
       delayExit: false,
       singleTimeout: 30000,
       stopOnFailure: false,
@@ -82,7 +81,6 @@ describe('Clis.forAuto', () => {
       testfiles: [
         'src/test/resources/test.file1'
       ],
-      debuggingPort: 9000,
       delayExit: false,
       singleTimeout: 30000,
       stopOnFailure: false,
@@ -121,7 +119,6 @@ describe('Clis.forAuto', () => {
       testfiles: [
         'src/test/resources/test.file1'
       ],
-      debuggingPort: 9000,
       delayExit: false,
       singleTimeout: 30000,
       stopOnFailure: false,
@@ -159,7 +156,6 @@ describe('Clis.forAuto', () => {
       testfiles: [
         'src/test/resources/test.file1'
       ],
-      debuggingPort: 9000,
       delayExit: false,
       singleTimeout: 30000,
       stopOnFailure: false,
@@ -179,8 +175,8 @@ describe('Clis.forAuto', () => {
     }, cleanResult(actual));
   });
 
-  // This isn't so much of desired test outcome, just a reality. If we don't have 
-  // a leading space in the extraBrowserCapabilities, and the first value in the 
+  // This isn't so much of desired test outcome, just a reality. If we don't have
+  // a leading space in the extraBrowserCapabilities, and the first value in the
   // string is --, then command-line-arguments (third party parser) will get confused
   // and throw errors.
   it('can not parse extra browser capabilities arguments without a leading space', () => {


### PR DESCRIPTION
Related Ticket: TINY-8703

Description of Changes:
* Updates how the default debugging port is generated so that it scans for an available port instead of being hardcoded to port 9000.
* Adds a console log when running in headless mode to print the debugger information
* Minor refactoring as to how headless mode is detected
* Allow `edge` to be used as a short hand alias for `MicrosoftEdge`

Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
