### PR TITLE
TINY-9097: Upgrade to the latest waluigi version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test-server": "yarn workspace @ephox/bedrock-server test",
     "test-sample": "yarn workspace @ephox/bedrock-sample test",
     "test-samples-fail": "yarn workspace @ephox/bedrock-sample test-samples-fail",
-    "test": "yarn build && yarn lint && yarn lerna run test"
+    "test": "yarn build && yarn lint && yarn lerna run --ignore @ephox/bedrock-sample test"
   },
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Related Ticket: TINY-9097

Description of Changes:
* Upgrade to the latest version of waluigi to build using containers
* Changed `yarn test` to not run the sample project tests since they are all run on the browsers anyways

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~package.json version bumped (if first change of new major/minor)~
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
