### PR TITLE
TINY-9097: Fixed lerna publish issues with new waluigi version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,9 @@ tinyPods.node() {
   if (isReleaseBranch()) {
     stage("publish") {
       tinyNpm.withNpmPublishCredentials {
-        exec('yarn lerna publish from-package --yes --ignore @ephox/bedrock-sample')
+        // We need to tell git to ignore the changes to .npmrc when publishing
+        exec('git update-index --assume-unchanged .npmrc')
+        exec('yarn lerna publish from-package --yes --no-git-reset --ignore @ephox/bedrock-sample')
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,38 +5,40 @@
 
 standardProperties()
 
-tinyPods.node() {
-  stage("clean") {
-    exec('yarn clean')
-  }
+timestamps {
+  tinyPods.node() {
+    stage("clean") {
+      exec('yarn clean')
+    }
 
-  stage("install") {
-    yarnInstall()
-  }
+    stage("install") {
+      yarnInstall()
+    }
 
-  stage("build") {
-    exec('yarn build')
-  }
+    stage("build") {
+      exec('yarn build')
+    }
 
-  stage("test") {
-    exec('yarn test')
+    stage("test") {
+      exec('yarn test')
 
-    bedrockBrowsers(
-      prepareTests: {
-        yarnInstall()
-        exec('yarn build')
-      },
-      testDirs: [ 'modules/sample/src/test/ts/**/pass' ],
-      custom: '--config modules/sample/tsconfig.json --customRoutes modules/sample/routes.json --polyfills Promise Symbol'
-    )
-  }
+      bedrockBrowsers(
+        prepareTests: {
+          yarnInstall()
+          exec('yarn build')
+        },
+        testDirs: [ 'modules/sample/src/test/ts/**/pass' ],
+        custom: '--config modules/sample/tsconfig.json --customRoutes modules/sample/routes.json --polyfills Promise Symbol'
+      )
+    }
 
-  if (isReleaseBranch()) {
-    stage("publish") {
-      tinyNpm.withNpmPublishCredentials {
-        // We need to tell git to ignore the changes to .npmrc when publishing
-        exec('git update-index --assume-unchanged .npmrc')
-        exec('yarn lerna publish from-package --yes --no-git-reset --ignore @ephox/bedrock-sample')
+    if (isReleaseBranch()) {
+      stage("publish") {
+        tinyNpm.withNpmPublishCredentials {
+          // We need to tell git to ignore the changes to .npmrc when publishing
+          exec('git update-index --assume-unchanged .npmrc')
+          exec('yarn lerna publish from-package --yes --no-git-reset --ignore @ephox/bedrock-sample')
+        }
       }
     }
   }


### PR DESCRIPTION
Related Ticket: TINY-9097

Description of Changes:

Lerna publish fails to run if there are uncommited changes and because we have to set npm config for the auth token this failed. So we now tell Git to ignore those changes before publishing.

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~package.json version bumped (if first change of new major/minor)~
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
