### PR TITLE
Update PR template to advise against manual changes to package.json versions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Description of Changes:
 
 Pre-checks:
 * [ ] Changelog entry added
-* [ ] package.json version bumped (if first change of new major/minor)
+* [ ] package.json versions have not been changed (done by Lerna on release)
 * [ ] Tests have been added (if applicable)
 
 Before merging:


### PR DESCRIPTION
Related Ticket: N/A

Description of Changes:
* Change checkbox to advise against manual changes to package.json versions in PR template since package.json versions are updated by Lerna on release

Pre-checks:
* [x] ~Changelog entry added~
* [x] ~package.json version bumped (if first change of new major/minor)~
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
