### PR TITLE
TINY-10014: Add --guest argument for MSEdge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Add `--guest` command line argument for Microsoft Edge to disable popups like the new Personalization experience. #TINY-10014
+
 ## 13.4.1 - 2023-06-09
 
 ### Fixed

--- a/modules/server/src/main/ts/bedrock/auto/Driver.ts
+++ b/modules/server/src/main/ts/bedrock/auto/Driver.ts
@@ -102,6 +102,8 @@ const getOptions = (port: number, browserName: string, settings: DriverSettings,
     addArguments(caps, 'goog:chromeOptions', extraCaps);
   } else if (browserName === 'firefox') {
     addArguments(caps, 'moz:firefoxOptions', extraCaps);
+  } else if (browserName === 'MicrosoftEdge') {
+    addArguments(caps, 'ms:edgeOptions', ['--guest']);
   } else if (browserName === 'internet explorer' && settings.wipeBrowserCache) {
     // Setup wiping the browser cache if required, as IE 11 doesn't use a clean session by default
     caps['se:ieOptions'] = {
@@ -136,15 +138,15 @@ const logDriverDetails = (driver: WebdriverIO.Browser<'async'>, headless: boolea
   const browserVersion = caps.browserVersion || caps.version;
 
   if (browserName === 'chrome') {
-    console.log('browser:', browserVersion, 'driver:', caps.chrome.chromedriverVersion);
+    console.log('chrome version:', browserVersion, 'driver:', caps.chrome.chromedriverVersion);
   } else if (browserName === 'firefox') {
-    console.log('browser:', browserVersion, 'driver:', caps['moz:geckodriverVersion']);
+    console.log('firefox version:', browserVersion, 'driver:', caps['moz:geckodriverVersion']);
   } else if (browserName === 'phantomjs') {
-    console.log('browser:', browserVersion, 'driver:', caps.driverVersion);
+    console.log('phantom version:', browserVersion, 'driver:', caps.driverVersion);
   } else if (browserName === 'MicrosoftEdge') {
-    console.log('browser:', browserVersion);
+    console.log('Edge version:', browserVersion);
   } else if (browserName === 'msedge') {
-    console.log('browser:', browserVersion, 'driver:', caps.msedge.msedgedriverVersion);
+    console.log('MSEdge version:', browserVersion, 'driver:', caps.msedge.msedgedriverVersion);
   }
 
   if (headless) {


### PR DESCRIPTION
Related Ticket: TINY-10014

Description of Changes:
* Guest mode in MS Edge is really what the webdriver should use by default, but here we go. At the moment it's disabling the new "Personalize your web experience" popup, which takes focus on windows.
* I also added the browser name to the startup console log, this helped with some debugging I was doing during development and it seemed useful so I left it in.

Pre-checks:
* [x] Changelog entry added
* [x] package.json versions have not been changed (done by Lerna on release)
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
