### PR TITLE
TINY-10281: Added node_module resolve routes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Improved
+
+- Urls like `/project/node_modules` and `/project/<package name>/node_modules` are now using node package resolve to serve files. #TINY-10281
+
 ## 13.5.0 - 2023-07-11
 
 ### Fixed
@@ -52,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Images (svg, png, gif, jpg, etc...) can now be imported by tests, and will be available as data URIs using the `asset/inline` webpack loader.
- 
+
 ## Improved
 - The mouse position reset logic now only runs when required, instead of for every test.
 

--- a/modules/server/src/main/ts/bedrock/server/Routes.ts
+++ b/modules/server/src/main/ts/bedrock/server/Routes.ts
@@ -193,7 +193,7 @@ export const nodeResolve = (method: HTTPMethod, prefix: string, source: string):
       done();
     };
 
-    const modulePath = request.url?.substring(prefix.length + 1);
+    const modulePath = request.url?.substring(prefix.length + 1).split('?')[0];
     try {
       if (modulePath) {
         const moduleResolvedPath = require.resolve(modulePath, { paths: [ source ] });

--- a/modules/server/src/main/ts/bedrock/server/RunnerRoutes.ts
+++ b/modules/server/src/main/ts/bedrock/server/RunnerRoutes.ts
@@ -61,7 +61,6 @@ export const generate = async (mode: string, projectdir: string, basedir: string
     ...nodeModuleRoutes,
     ...resourceRoutes,
     ...[
-      // fallback node_modules route to from project root
       Routes.nodeResolve('GET', '/project/node_modules', projectdir),
 
       // fallback resource route to project root

--- a/modules/server/src/main/ts/bedrock/server/RunnerRoutes.ts
+++ b/modules/server/src/main/ts/bedrock/server/RunnerRoutes.ts
@@ -51,39 +51,48 @@ export const generate = async (mode: string, projectdir: string, basedir: string
 
   // console.log(`Resource maps from ${projectdir}: \n`, resourceRoots.map(({ name, folder }) => `/project/${name}/ => ${folder}`));
 
+  const nodeModuleRoutes = resourceRoots.map(({name, folder}) => Routes.nodeResolve('GET', `/project/${name}/node_modules`, path.join(projectdir, folder)));
+
   const resourceRoutes = resourceRoots.map(({name, folder}) => Routes.routing('GET', `/project/${name}`, path.join(projectdir, folder)));
 
   const precompiledTests = mode === 'auto' ? await testGenerator.generate() : null;
 
-  const routers = resourceRoutes.concat([
-    // fallback resource route to project root
-    Routes.routing('GET', '/project', projectdir),
+  const routers = [
+    ...nodeModuleRoutes,
+    ...resourceRoutes,
+    ...[
+      // fallback node_modules route to from project root
+      Routes.nodeResolve('GET', '/project/node_modules', projectdir),
 
-    // bedrock resources
-    Routes.routing('GET', '/runner', path.join(require.resolve('@ephox/bedrock-runner'), '../../../../../dist')),
-    Routes.routing('GET', '/lib/jquery', path.dirname(require.resolve('jquery'))),
-    Routes.routing('GET', '/lib/core-js-bundle', path.dirname(require.resolve('core-js-bundle'))),
-    Routes.routing('GET', '/css', path.join(basedir, 'src/resources/css')),
+      // fallback resource route to project root
+      Routes.routing('GET', '/project', projectdir),
 
-    // test code
-    Routes.asyncJs('GET', '/compiled/tests.js', (done) => {
-      if (precompiledTests !== null) {
-        done(precompiledTests);
-      } else {
-        testGenerator.generate().then(done);
-      }
-    }),
-    Routes.routing('GET', '/compiled', path.join(projectdir, 'scratch/compiled')),
+      // bedrock resources
+      Routes.routing('GET', '/runner', path.join(require.resolve('@ephox/bedrock-runner'), '../../../../../dist')),
+      Routes.routing('GET', '/lib/jquery', path.dirname(require.resolve('jquery'))),
+      Routes.routing('GET', '/lib/core-js-bundle', path.dirname(require.resolve('core-js-bundle'))),
+      Routes.routing('GET', '/css', path.join(basedir, 'src/resources/css')),
 
-    // harness API
-    Routes.json('GET', '/harness', {
-      stopOnFailure,
-      chunk,
-      retries,
-      timeout: singleTimeout,
-      mode
-    })
-  ]);
+      // test code
+      Routes.asyncJs('GET', '/compiled/tests.js', (done) => {
+        if (precompiledTests !== null) {
+          done(precompiledTests);
+        } else {
+          testGenerator.generate().then(done);
+        }
+      }),
+      Routes.routing('GET', '/compiled', path.join(projectdir, 'scratch/compiled')),
+
+      // harness API
+      Routes.json('GET', '/harness', {
+        stopOnFailure,
+        chunk,
+        retries,
+        timeout: singleTimeout,
+        mode
+      })
+    ]
+  ];
 
   const fallback = Routes.constant('GET', basedir, basePage);
 


### PR DESCRIPTION
Related Ticket: TINY-10281

Description of Changes:
* Added missing .editorconfig file
* Added new node resolve based routes
* Cleaned up the concat of routes so that it uses the spread operator instead

Pre-checks:
* [x] Changelog entry added
* [x] package.json versions have not been changed (done by Lerna on release)
* [x] Tests have been added (if applicable)

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
