### PR TITLE
TINY-10466: Add browserVersion and platformName args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add `--platformName` and `--browserVersion` arguments for Lambdatest #TINY-10466
+
 ## 14.0.0 - 2023-11-27
 
 ### Added

--- a/modules/server/src/main/ts/BedrockAuto.ts
+++ b/modules/server/src/main/ts/BedrockAuto.ts
@@ -69,7 +69,9 @@ export const go = (bedrockAutoSettings: BedrockAutoSettings): void => {
       username,
       accesskey,
       devicefarmRegion: settings.devicefarmRegion,
-      deviceFarmArn: settings.devicefarmArn
+      deviceFarmArn: settings.devicefarmArn,
+      browserVersion: settings.browserVersion,
+      platformName: settings.platformName
     });
 
     const webdriver = driver.webdriver;

--- a/modules/server/src/main/ts/bedrock/auto/Driver.ts
+++ b/modules/server/src/main/ts/bedrock/auto/Driver.ts
@@ -28,6 +28,8 @@ export interface DriverSettings {
   accesskey?: string;
   devicefarmRegion?: string;
   deviceFarmArn?: string;
+  platformName?: string;
+  browserVersion: string;
 }
 
 export interface Driver {

--- a/modules/server/src/main/ts/bedrock/auto/RemoteDriver.ts
+++ b/modules/server/src/main/ts/bedrock/auto/RemoteDriver.ts
@@ -78,6 +78,7 @@ export const getApi = async (settings: DriverSettings, browser: string, opts: We
 
 const addDriverSpecificOpts = (opts: WebdriverIO.RemoteOptions, settings: DriverSettings): WebdriverIO.RemoteOptions => {
   if (settings.remoteWebdriver === 'lambdatest') {
+    const platformName = settings.platformName ? { platformName: settings.platformName } : {};
     return deepmerge(opts, {
       user: settings.username,
       key: settings.accesskey,
@@ -88,7 +89,8 @@ const addDriverSpecificOpts = (opts: WebdriverIO.RemoteOptions, settings: Driver
           tunnel: true,
           console: true,
           w3c: true,
-          plugin: 'node_js-webdriverio'
+          plugin: 'node_js-webdriverio',
+          ...platformName
         }
       }
     });
@@ -113,7 +115,7 @@ const addBrowserSpecificOpts = (opts: WebdriverIO.RemoteOptions, browser: string
 export const getOpts = (browserName: string, settings: DriverSettings): WebdriverIO.RemoteOptions => {
   const driverOpts: WebdriverIO.RemoteOptions = {
     capabilities: {
-      browserVersion: 'latest'
+      browserVersion: settings.browserVersion
     }
   };
   const withBrowserOpts = addDriverSpecificOpts(driverOpts, settings);

--- a/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
+++ b/modules/server/src/main/ts/bedrock/cli/ClOptions.ts
@@ -363,6 +363,21 @@ export const devicefarmArn: ClOption = {
   validate: Extraction.any
 };
 
+export const browserVersion: ClOption = {
+  name: 'browserVersion',
+  type: String,
+  defaultValue: 'latest',
+  description: 'Browser version used by lambdatest, defaults to "latest"',
+  validate: Extraction.any
+};
+
+export const platformName: ClOption = {
+  name: 'platformName',
+  type: String,
+  description: 'Platform name used by lambdatest',
+  validate: Extraction.any
+};
+
 export const useSelenium: ClOption = {
   name: 'useSelenium',
   type: Boolean,

--- a/modules/server/src/main/ts/bedrock/cli/Clis.ts
+++ b/modules/server/src/main/ts/bedrock/cli/Clis.ts
@@ -56,6 +56,8 @@ export const forAuto = (directories: Directories, argv: string[] = process.argv)
     ClOptions.accesskey,
     ClOptions.devicefarmArn,
     ClOptions.devicefarmRegion,
+    ClOptions.browserVersion,
+    ClOptions.platformName,
     ClOptions.useSelenium
   ]), argv) as Attempt<cli.CliError, BedrockAutoSettings>;
 };

--- a/modules/server/src/main/ts/bedrock/core/Settings.ts
+++ b/modules/server/src/main/ts/bedrock/core/Settings.ts
@@ -41,4 +41,6 @@ export interface BedrockAutoSettings extends BedrockSettings {
   readonly accesskey: string;
   readonly devicefarmRegion: string;
   readonly devicefarmArn: string;
+  readonly browserVersion: string;
+  readonly platformName?: string;
 }

--- a/modules/server/src/test/ts/ClisTest.ts
+++ b/modules/server/src/test/ts/ClisTest.ts
@@ -36,6 +36,7 @@ describe('Clis.forAuto', () => {
     const actual = Clis.forAuto(directories, args);
     AttemptUtils.assertResult({
       browser: 'MicrosoftEdge',
+      browserVersion: 'latest',
       bundler: 'webpack',
       config: 'src/test/resources/tsconfig.sample.json',
       name: 'bedrock-run',
@@ -76,6 +77,7 @@ describe('Clis.forAuto', () => {
     const actual = Clis.forAuto(directories, args);
     AttemptUtils.assertResult({
       browser: 'MicrosoftEdge',
+      browserVersion: 'latest',
       bundler: 'webpack',
       config: 'src/test/resources/tsconfig.sample.json',
       name: 'bedrock-run',
@@ -117,6 +119,7 @@ describe('Clis.forAuto', () => {
     const actual = Clis.forAuto(directories, args);
     AttemptUtils.assertResult({
       browser: 'MicrosoftEdge',
+      browserVersion: 'latest',
       bundler: 'webpack',
       config: 'src/test/resources/tsconfig.sample.json',
       name: 'bedrock-run',
@@ -157,6 +160,7 @@ describe('Clis.forAuto', () => {
     const actual = Clis.forAuto(directories, args);
     AttemptUtils.assertResult({
       browser: 'chrome-headless',
+      browserVersion: 'latest',
       bundler: 'webpack',
       config: 'src/test/resources/tsconfig.sample.json',
       name: 'bedrock-run',
@@ -193,11 +197,14 @@ describe('Clis.forAuto', () => {
       '--files', 'src/test/resources/test.file1',
       '--username', 'lt_username',
       '--accesskey', 'lt_access_key',
-      '--remote', 'lambdatest'
+      '--remote', 'lambdatest',
+      '--platformName', 'macOS Catalina',
+      '--browserVersion', '117.0'
     ];
     const actual = Clis.forAuto(directories, args);
     AttemptUtils.assertResult({
       browser: 'chrome-headless',
+      browserVersion: '117.0',
       bundler: 'webpack',
       config: 'tsconfig.json',
       name: 'bedrock-run',
@@ -226,7 +233,8 @@ describe('Clis.forAuto', () => {
       remote: 'lambdatest',
       username: 'lt_username',
       accesskey: 'lt_access_key',
-      webdriverPort: 4444
+      webdriverPort: 4444,
+      platformName: 'macOS Catalina'
     }, cleanResult(actual));
   });
 
@@ -242,6 +250,7 @@ describe('Clis.forAuto', () => {
     const actual = Clis.forAuto(directories, args);
     AttemptUtils.assertResult({
       browser: 'chrome-headless',
+      browserVersion: 'latest',
       bundler: 'webpack',
       config: 'tsconfig.json',
       name: 'bedrock-run',


### PR DESCRIPTION
Related Ticket: TINY-10466

Description of Changes:
* Add browserVersion and platformName args for remote testing

Pre-checks:
* [x] Changelog entry added
* [x] package.json versions have not been changed (done by Lerna on release)
* [x] Tests have been added (if applicable)

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
