### PR TITLE
TINY-10490: add mouse right click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add `rightClick` to `MouseEffect.ts` #TINY-10490
+
 ## 14.1.0 - 2023-12-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Add `rightClick` to `MouseEffect.ts` #TINY-10490
+- Added `rightClick` to `MouseEffect.ts` #TINY-10490
 
 ## 14.1.0 - 2023-12-14
 

--- a/modules/server/src/main/ts/bedrock/server/MouseEffects.ts
+++ b/modules/server/src/main/ts/bedrock/server/MouseEffects.ts
@@ -8,7 +8,7 @@ import * as EffectUtils from './EffectUtils';
  }
  */
 export interface MouseData {
-  readonly type: 'move' | 'click' | 'down' | 'up';
+  readonly type: 'move' | 'click' | 'rightClick' | 'down' | 'up';
   readonly selector: string;
 }
 
@@ -36,6 +36,8 @@ const doAction = async (target: EffectUtils.ElementWithActions, type: MouseData[
   // MicrosoftEdge does support this, but does not seem to support click in an ActionSequence
   } else if (type === 'click') {
     return target.click();
+  } else if (type === 'rightClick') {
+    return target.click({ button: 'right' });
   } else {
     return Promise.reject('Unknown mouse effect type: ' + type);
   }


### PR DESCRIPTION
Related Ticket: TINY-10490

Description of Changes:
to test the issue for `TINY-10490` I need a real right click, I think this feature could be useful also for other tests

Pre-checks:
* [x] Changelog entry added
* [x] package.json versions have not been changed (done by Lerna on release)
* [x] ~Tests have been added (if applicable)~

Before merging:
* [ ] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
