### PR TITLE
TINY-10688: Support using `pnpm-workspace.yaml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Improved
+- Now supports using `pnpm-workspace.yaml` to fetch workspaces.
+
 ## 14.1.2 - 2024-01-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Improved
-- Now supports using `pnpm-workspace.yaml` to fetch workspaces.
+- Now supports using `pnpm-workspace.yaml` to fetch workspaces #TINY-10688
 
 ## 14.1.2 - 2024-01-31
 

--- a/modules/server/src/main/ts/bedrock/server/RunnerRoutes.ts
+++ b/modules/server/src/main/ts/bedrock/server/RunnerRoutes.ts
@@ -54,17 +54,19 @@ export const generate = async (mode: string, projectdir: string, basedir: string
 
     return new Promise<WorkspaceRoot[]>((resolve, reject) =>
       childProcess.exec('pnpm list -r --only-projects --json', (err, stdout, stderr) => {
-        if (err) reject(err);
-        else if (stderr) reject(stderr);
-        else {
-          const result: WorkspaceRoot[] = [];
-          for (const p of JSON.parse(stdout) as { name: string; path: string }[]) {
-            const folder = path.relative(projectdir, p.path);
-            if (!folder.length) continue;
-            result.push({ name: p.name, folder });
-          }
-          resolve(result);
+        if (stderr) console.error(stderr);
+        if (err) {
+          reject(err);
+          return;
         }
+
+        const result: WorkspaceRoot[] = [];
+        for (const p of JSON.parse(stdout) as { name: string; path: string }[]) {
+          const folder = path.relative(projectdir, p.path);
+          if (!folder.length) continue;
+          result.push({ name: p.name, folder });
+        }
+        resolve(result);
       })
     );
   };

--- a/modules/server/src/main/ts/bedrock/server/RunnerRoutes.ts
+++ b/modules/server/src/main/ts/bedrock/server/RunnerRoutes.ts
@@ -57,11 +57,13 @@ export const generate = async (mode: string, projectdir: string, basedir: string
         if (err) reject(err);
         else if (stderr) reject(stderr);
         else {
-          resolve(
-            (JSON.parse(stdout) as { name: string; path: string }[])
-              .map((p) => ({ name: p.name, folder: path.relative(projectdir, p.path) }))
-              .filter((p) => p.folder)
-          );
+          const result: WorkspaceRoot[] = [];
+          for (const p of JSON.parse(stdout) as { name: string; path: string }[]) {
+            const folder = path.relative(projectdir, p.path);
+            if (!folder.length) continue;
+            result.push({ name: p.name, folder });
+          }
+          resolve(result);
         }
       })
     );


### PR DESCRIPTION
Related Ticket: TINY-10688

Description of Changes:
If the `workspaces` prop inside of the project's `package.json` is unused, check if there's a `pnpm-workspace.yaml` file then use `pnpm list -r --only-projects --json` to find workspaces instead.

Pre-checks:
* [x] Changelog entry added
* [x] package.json versions have not been changed (done by Lerna on release)
* [X] ~Tests have been added (if applicable)~

Before merging:
* [ ] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
