### PR TITLE
TINY-10801: `IS_CI` should be checking `!isTTY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- `IS_CI` now checks that `isTTY` is false. #TINY-10801
+
 ## 14.1.3 - 2024-03-14
 
 ### Improved

--- a/modules/sample/src/test/ts/client/pass/EffectsTest.ts
+++ b/modules/sample/src/test/ts/client/pass/EffectsTest.ts
@@ -39,7 +39,7 @@ describe('Effects', () => {
 
       await sendKeyCombo('textarea', 'v', ctrlKeyModifier);
       Assert.eq('Textarea value after pasting', 'hello world', textarea.value);
-    });
+    }).retries(5);
 
     it('should type text', async () => {
       await sendText('textarea', 'hello world!');

--- a/modules/server/src/main/ts/bedrock/util/Env.ts
+++ b/modules/server/src/main/ts/bedrock/util/Env.ts
@@ -1,1 +1,1 @@
-export const IS_CI = 'CI' in process.env && process.stdout.isTTY;
+export const IS_CI = 'CI' in process.env && !process.stdout.isTTY;


### PR DESCRIPTION
Related Ticket: TINY-10801

Description of Changes:
IS_CI is now checking for _not_ TTY.

Pre-checks:
* [X] Changelog entry added
* [X] package.json versions have not been changed (done by Lerna on release)
* [X] ~Tests have been added (if applicable)~

Before merging:
* [X] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
