### PR TITLE
TINY-11252: Add terminal and network logging

### DIFF
--- a/modules/server/src/main/ts/bedrock/auto/RemoteDriver.ts
+++ b/modules/server/src/main/ts/bedrock/auto/RemoteDriver.ts
@@ -104,6 +104,8 @@ const addDriverSpecificOpts = (opts: WebdriverIO.RemoteOptions, settings: Driver
           tunnel: true,
           console: true,
           w3c: true,
+          network: true,
+          terminal: true,
           plugin: 'node_js-webdriverio',
           ...platformName,
           ...tunnelName,


### PR DESCRIPTION
I don't think we need to hide this logging behind a CLI option

Related Ticket: TINY-11252

Description of Changes:
* Enable terminal and network logging for lambdatest

Pre-checks:
* [x] Changelog entry added
* [x] package.json versions have not been changed (done by Lerna on release)
* [x] Tests have been added (if applicable)

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
