### PR TITLE
TINY-11177: Ensure that a failed/retry test that passes is reported immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Improved
+- Remote webdriver session ID is now logged after connecting #TINY-10835
+
+## Fixed
+- Failing tests that retry and then pass could exceed the "tests crashed" server timeout #TINY-11177
+
 ## 15.0.1 - 2025-01-27
 
 ## Fixed
-- AWS remote testing idle timeout was not set
+- AWS remote testing idle timeout was not set #TINY-11177
 
 ## 15.0.0 - 2025-01-27
 


### PR DESCRIPTION
Related Ticket: TINY-11177

Description of Changes:
* While running tests with bedrock 15 I noticed that Firefox was sometimes hitting the server-side timeout after tests failed and were retried.
* I tracked this down to code I added which [hides the test under retry from the server](https://github.com/tinymce/bedrock/blob/867332a4c25a86e7f0c9505c22414e8d42148e79/modules/runner/src/main/ts/reporter/Reporter.ts#L205-L210). As a result, if the client did a retry with no other test results to report no message would be sent to the server.
* This turns out to conflict with other optimisations that don't send any messages to the server after a reload until 30 seconds have passed.
* Remote selenium has slower load times, so if the retry took long enough this would bump into the server-side time limit.
* The change I'm making here is to immediately send a test result after a passing retry. Hopefully that avoids the timeout.
* We still need to update our test suite to not require retries during a standard test run, but one step at a time.

Pre-checks:
* [x] Changelog entry added
* [x] package.json versions have not been changed (done by Lerna on release)
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable